### PR TITLE
Replace UMAP with PCA for deterministic latentspace

### DIFF
--- a/.claude/skills/build-latentspace/scripts/build_post_map.py
+++ b/.claude/skills/build-latentspace/scripts/build_post_map.py
@@ -1,21 +1,20 @@
 """
-Embed blog posts with OpenAI text-embedding-3-small and reduce to 2D with UMAP.
-Outputs assets/data/latentspace.json for D3.js visualization.
+Embed blog posts with OpenAI text-embedding-3-small and reduce to 2D with PCA.
+Outputs data/latentspace.json for D3.js visualization.
 
-Incremental mode: existing posts keep their xy from latentspace.json.
-Only new posts are embedded and projected via cached UMAP model.
-Cache files: umap_model.pkl (fitted UMAP model).
+PCA is fully deterministic: same inputs always produce identical coordinates.
+Adding a post causes only minimal coordinate shifts (~1/N).
+Cached embeddings avoid redundant OpenAI API calls.
 """
 
 import glob
 import json
 import os
-import pickle
 import re
 
 from bs4 import BeautifulSoup
 from openai import OpenAI
-from umap import UMAP
+from sklearn.decomposition import PCA
 import numpy as np
 
 EMOJI_TO_LABEL = {
@@ -31,7 +30,7 @@ EMOJI_TO_LABEL = {
 REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 DATA_DIR = os.path.join(REPO_ROOT, "data")
 LATENTSPACE_PATH = os.path.join(DATA_DIR, "latentspace.json")
-UMAP_MODEL_PATH = os.path.join(DATA_DIR, "umap_model.pkl")
+EMBEDDINGS_PATH = os.path.join(DATA_DIR, "embeddings.json")
 
 
 def parse_frontmatter(raw):
@@ -143,28 +142,26 @@ def get_embeddings(posts, client):
     return np.array(embeddings)
 
 
-def load_existing_coords():
-    """Load existing latentspace.json coords as {slug: {x, y}}."""
-    if not os.path.exists(LATENTSPACE_PATH):
+def load_cached_embeddings():
+    """Load cached embeddings as {slug: [float, ...]}."""
+    if not os.path.exists(EMBEDDINGS_PATH):
         return {}
-    with open(LATENTSPACE_PATH, encoding="utf-8") as f:
-        data = json.load(f)
-    return {d["slug"]: {"x": d["x"], "y": d["y"]} for d in data}
+    try:
+        with open(EMBEDDINGS_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except (json.JSONDecodeError, ValueError):
+        print("Warning: corrupt embeddings cache, starting fresh")
+        return {}
 
 
-def load_umap_model():
-    """Load cached UMAP model if available."""
-    if not os.path.exists(UMAP_MODEL_PATH):
-        return None
-    with open(UMAP_MODEL_PATH, "rb") as f:
-        return pickle.load(f)
-
-
-def save_umap_model(reducer):
-    """Save fitted UMAP model."""
+def save_cached_embeddings(embeddings_dict):
+    """Save embeddings cache."""
     os.makedirs(DATA_DIR, exist_ok=True)
-    with open(UMAP_MODEL_PATH, "wb") as f:
-        pickle.dump(reducer, f)
+    with open(EMBEDDINGS_PATH, "w", encoding="utf-8") as f:
+        json.dump(embeddings_dict, f)
 
 
 def normalize_coords(coords):
@@ -182,65 +179,46 @@ def main():
     posts = load_posts()
     print(f"Loaded {len(posts)} posts")
 
-    existing_coords = load_existing_coords()
-    cached_reducer = load_umap_model()
+    # Load cached embeddings to avoid redundant API calls
+    cached_embeddings = load_cached_embeddings()
+    new_slugs = [p["slug"] for p in posts if p["slug"] not in cached_embeddings]
+    cached_slugs = [p["slug"] for p in posts if p["slug"] in cached_embeddings]
 
-    new_posts = [p for p in posts if p["slug"] not in existing_coords]
-    kept_posts = [p for p in posts if p["slug"] in existing_coords]
+    print(f"Cached: {len(cached_slugs)}, New: {len(new_slugs)}")
 
-    print(f"Existing: {len(kept_posts)}, New: {len(new_posts)}")
-
-    if len(new_posts) == 0:
-        print("No new posts. Updating metadata only.")
-    elif cached_reducer is not None:
-        # Incremental: embed new posts, project via cached UMAP model
-        new_embeddings = get_embeddings(new_posts, client)
-        new_coords_2d = cached_reducer.transform(new_embeddings)
-
-        # Map raw UMAP coords to [0,1] using the model's fitted embedding range
-        raw_embedding = cached_reducer.embedding_
-        raw_min = raw_embedding.min(axis=0)
-        raw_max = raw_embedding.max(axis=0)
-        raw_range = raw_max - raw_min
-
+    # Embed only new posts
+    if new_slugs:
+        new_posts = [p for p in posts if p["slug"] in set(new_slugs)]
+        new_emb = get_embeddings(new_posts, client)
         for i, post in enumerate(new_posts):
-            nx = (new_coords_2d[i, 0] - raw_min[0]) / raw_range[0] if raw_range[0] > 0 else 0.5
-            ny = (new_coords_2d[i, 1] - raw_min[1]) / raw_range[1] if raw_range[1] > 0 else 0.5
-            existing_coords[post["slug"]] = {
-                "x": round(float(max(0, min(1, nx))), 4),
-                "y": round(float(max(0, min(1, ny))), 4),
-            }
-
-        print(f"Projected {len(new_posts)} new posts via UMAP transform()")
+            cached_embeddings[post["slug"]] = new_emb[i].tolist()
+        print(f"Embedded {len(new_slugs)} new posts")
     else:
-        # Full rebuild
-        print("Full rebuild (no cache found)")
-        all_embeddings = get_embeddings(posts, client)
+        print("No new posts to embed")
 
-        reducer = UMAP(
-            n_components=2,
-            n_neighbors=15,
-            min_dist=0.1,
-            metric="cosine",
-            random_state=42,
-        )
-        raw_coords = reducer.fit_transform(all_embeddings)
-        coords_normalized = normalize_coords(raw_coords)
+    # Remove deleted posts from cache
+    valid_slugs = {p["slug"] for p in posts}
+    stale_slugs = set(cached_embeddings.keys()) - valid_slugs
+    if stale_slugs:
+        cached_embeddings = {k: v for k, v in cached_embeddings.items() if k in valid_slugs}
+        print(f"Pruned {len(stale_slugs)} stale entries from cache")
+    save_cached_embeddings(cached_embeddings)
 
-        for i, post in enumerate(posts):
-            existing_coords[post["slug"]] = {
-                "x": round(float(coords_normalized[i, 0]), 4),
-                "y": round(float(coords_normalized[i, 1]), 4),
-            }
+    # Build embedding matrix in post order
+    all_embeddings = np.array([cached_embeddings[p["slug"]] for p in posts])
 
-        save_umap_model(reducer)
+    # PCA to 2D — fully deterministic
+    pca = PCA(n_components=2)
+    coords_2d = pca.fit_transform(all_embeddings)
+    coords_normalized = normalize_coords(coords_2d)
+
+    print(f"PCA explained variance: {pca.explained_variance_ratio_}")
 
     # Build output
     valid_slugs = {p["slug"] for p in posts}
     output = []
-    for post in posts:
+    for i, post in enumerate(posts):
         slug = post["slug"]
-        coord = existing_coords.get(slug, {"x": 0.5, "y": 0.5})
         connected = [s for s in post["connected"] if s in valid_slugs and s != slug]
         output.append({
             "title": post["title"],
@@ -249,8 +227,8 @@ def main():
             "category": post["category"],
             "label": post["label"],
             "connected": connected,
-            "x": coord["x"],
-            "y": coord["y"],
+            "x": round(float(coords_normalized[i, 0]), 4),
+            "y": round(float(coords_normalized[i, 1]), 4),
         })
 
     os.makedirs(DATA_DIR, exist_ok=True)

--- a/.claude/skills/build-latentspace/scripts/test_build_post_map.py
+++ b/.claude/skills/build-latentspace/scripts/test_build_post_map.py
@@ -1,0 +1,238 @@
+"""Tests for build_post_map.py — embedding cache skip logic.
+
+Guards against unnecessary OpenAI API calls (= real money).
+"""
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+import pytest
+
+import build_post_map as bpm
+
+
+@pytest.fixture
+def tmp_data_dir(tmp_path):
+    """Redirect DATA_DIR / paths to a temp directory."""
+    with patch.object(bpm, "DATA_DIR", str(tmp_path)), \
+         patch.object(bpm, "EMBEDDINGS_PATH", str(tmp_path / "embeddings.json")), \
+         patch.object(bpm, "LATENTSPACE_PATH", str(tmp_path / "latentspace.json")):
+        yield tmp_path
+
+
+FAKE_DIM = 8
+
+
+def _fake_posts(slugs):
+    return [
+        {
+            "title": f"Post {s}",
+            "slug": s,
+            "url": f"/{s}/",
+            "category": "note",
+            "label": "Note",
+            "connected": [],
+            "embed_text": f"text for {s}",
+        }
+        for s in slugs
+    ]
+
+
+def _fake_embedding(n=1):
+    rng = np.random.RandomState(42)
+    return rng.randn(n, FAKE_DIM)
+
+
+class TestCacheSkip:
+    """Verify that cached slugs skip the API call."""
+
+    def test_all_cached_skips_api(self, tmp_data_dir):
+        """When all slugs exist in cache, get_embeddings must NOT be called."""
+        slugs = ["aaa", "bbb", "ccc"]
+        cache = {s: np.random.randn(FAKE_DIM).tolist() for s in slugs}
+        with open(tmp_data_dir / "embeddings.json", "w") as f:
+            json.dump(cache, f)
+
+        posts = _fake_posts(slugs)
+
+        mock_client = MagicMock()
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", wraps=bpm.get_embeddings) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        mock_embed.assert_not_called()
+
+    def test_partial_cache_embeds_only_new(self, tmp_data_dir):
+        """When some slugs are cached, only new ones hit the API."""
+        cached_slugs = ["aaa", "bbb"]
+        new_slugs = ["ccc"]
+        all_slugs = cached_slugs + new_slugs
+
+        cache = {s: np.random.randn(FAKE_DIM).tolist() for s in cached_slugs}
+        with open(tmp_data_dir / "embeddings.json", "w") as f:
+            json.dump(cache, f)
+
+        posts = _fake_posts(all_slugs)
+
+        mock_client = MagicMock()
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", return_value=_fake_embedding(len(new_slugs))) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        mock_embed.assert_called_once()
+        embedded_posts = mock_embed.call_args[0][0]
+        assert [p["slug"] for p in embedded_posts] == new_slugs
+
+    def test_empty_cache_embeds_all(self, tmp_data_dir):
+        """When cache is empty, all posts are embedded."""
+        slugs = ["aaa", "bbb", "ccc"]
+        posts = _fake_posts(slugs)
+
+        mock_client = MagicMock()
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", return_value=_fake_embedding(len(slugs))) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        mock_embed.assert_called_once()
+        embedded_posts = mock_embed.call_args[0][0]
+        assert [p["slug"] for p in embedded_posts] == slugs
+
+    def test_deleted_post_removed_from_cache(self, tmp_data_dir):
+        """Slugs in cache but not in posts should be pruned."""
+        cache = {s: np.random.randn(FAKE_DIM).tolist() for s in ["aaa", "bbb", "deleted"]}
+        with open(tmp_data_dir / "embeddings.json", "w") as f:
+            json.dump(cache, f)
+
+        posts = _fake_posts(["aaa", "bbb", "new"])
+
+        mock_client = MagicMock()
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", return_value=_fake_embedding(1)) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        saved = json.load(open(tmp_data_dir / "embeddings.json"))
+        assert "deleted" not in saved
+        assert set(saved.keys()) == {"aaa", "bbb", "new"}
+
+    def test_output_json_has_all_posts(self, tmp_data_dir):
+        """latentspace.json should contain all posts with valid coords."""
+        slugs = ["aaa", "bbb", "ccc"]
+        cache = {s: np.random.randn(FAKE_DIM).tolist() for s in slugs}
+        with open(tmp_data_dir / "embeddings.json", "w") as f:
+            json.dump(cache, f)
+
+        posts = _fake_posts(slugs)
+
+        mock_client = MagicMock()
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        output = json.load(open(tmp_data_dir / "latentspace.json"))
+        assert len(output) == len(slugs)
+        for entry in output:
+            assert 0.0 <= entry["x"] <= 1.0
+            assert 0.0 <= entry["y"] <= 1.0
+
+    def test_pca_determinism(self, tmp_data_dir):
+        """Same embeddings should produce identical coordinates."""
+        slugs = ["aaa", "bbb", "ccc"]
+        rng = np.random.RandomState(123)
+        cache = {s: rng.randn(FAKE_DIM).tolist() for s in slugs}
+
+        posts = _fake_posts(slugs)
+        mock_client = MagicMock()
+
+        results = []
+        for _ in range(2):
+            with open(tmp_data_dir / "embeddings.json", "w") as f:
+                json.dump(cache, f)
+            with patch.object(bpm, "load_posts", return_value=posts), \
+                 patch.object(bpm, "OpenAI", return_value=mock_client):
+                bpm.main()
+            results.append(json.load(open(tmp_data_dir / "latentspace.json")))
+
+        for a, b in zip(results[0], results[1]):
+            assert a["x"] == b["x"]
+            assert a["y"] == b["y"]
+
+    def test_consecutive_runs_skip_api(self, tmp_data_dir):
+        """Running main() twice in a row: second run must not call API."""
+        slugs = ["aaa", "bbb", "ccc"]
+        posts = _fake_posts(slugs)
+        mock_client = MagicMock()
+
+        # First run: embed everything
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", return_value=_fake_embedding(len(slugs))) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+        assert mock_embed.call_count == 1
+
+        # Second run: cache should cover all slugs
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", wraps=bpm.get_embeddings) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+        mock_embed.assert_not_called()
+
+    def test_deleted_post_pruned_without_new_posts(self, tmp_data_dir):
+        """Stale cache entries should be pruned even when no new posts exist."""
+        cache = {s: np.random.randn(FAKE_DIM).tolist() for s in ["aaa", "bbb", "deleted"]}
+        with open(tmp_data_dir / "embeddings.json", "w") as f:
+            json.dump(cache, f)
+
+        # Only aaa and bbb remain — no new posts, but "deleted" should be pruned
+        posts = _fake_posts(["aaa", "bbb"])
+        mock_client = MagicMock()
+
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", wraps=bpm.get_embeddings) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        mock_embed.assert_not_called()
+        saved = json.load(open(tmp_data_dir / "embeddings.json"))
+        assert "deleted" not in saved
+        assert set(saved.keys()) == {"aaa", "bbb"}
+
+    def test_corrupt_cache_triggers_full_embed(self, tmp_data_dir):
+        """If cache file is corrupt JSON, all posts should be re-embedded."""
+        with open(tmp_data_dir / "embeddings.json", "w") as f:
+            f.write("{broken json")
+
+        slugs = ["aaa", "bbb"]
+        posts = _fake_posts(slugs)
+        mock_client = MagicMock()
+
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", return_value=_fake_embedding(len(slugs))) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        mock_embed.assert_called_once()
+        embedded_posts = mock_embed.call_args[0][0]
+        assert len(embedded_posts) == len(slugs)
+
+    def test_no_cache_file_embeds_all(self, tmp_data_dir):
+        """If embeddings.json doesn't exist, all posts should be embedded."""
+        assert not os.path.exists(tmp_data_dir / "embeddings.json")
+
+        slugs = ["aaa", "bbb"]
+        posts = _fake_posts(slugs)
+        mock_client = MagicMock()
+
+        with patch.object(bpm, "load_posts", return_value=posts), \
+             patch.object(bpm, "get_embeddings", return_value=_fake_embedding(len(slugs))) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        mock_embed.assert_called_once()
+        assert len(mock_embed.call_args[0][0]) == len(slugs)

--- a/.github/workflows/build-latentspace.yml
+++ b/.github/workflows/build-latentspace.yml
@@ -20,12 +20,14 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install openai beautifulsoup4 lxml numpy scikit-learn umap-learn
+        run: pip install openai beautifulsoup4 lxml numpy scikit-learn pytest
+
+      - name: Run tests
+        run: python3 -m pytest .claude/skills/build-latentspace/scripts/test_build_post_map.py -v
 
       - name: Build latentspace.json
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          NUMBA_DISABLE_JIT: "1"
         run: python3 .claude/skills/build-latentspace/scripts/build_post_map.py
 
       - name: Verify output
@@ -42,7 +44,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/latentspace.json data/umap_model.pkl
+          git add data/latentspace.json data/embeddings.json
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/_sass/latentspace.sass
+++ b/_sass/latentspace.sass
@@ -20,14 +20,13 @@ $map-text-color: $text-dark
 
 #post-map
   position: relative
-  margin-top: 1em
-  margin-bottom: 1em
+  margin-top: 0.5em
+  margin-bottom: 0.5em
   width: 100%
   aspect-ratio: 16 / 9
 
 #post-map svg
   display: block
-  margin-top: 1.5em
 
 .map-tooltip
   position: absolute

--- a/data/latentspace.json
+++ b/data/latentspace.json
@@ -8,8 +8,8 @@
     "connected": [
       "reading-list"
     ],
-    "x": 0.5387,
-    "y": 0.8145
+    "x": 0.5702,
+    "y": 0.8362
   },
   {
     "title": "Reading List",
@@ -22,8 +22,8 @@
       "gan",
       "cvs"
     ],
-    "x": 0.5887,
-    "y": 0.5696
+    "x": 0.8422,
+    "y": 0.3343
   },
   {
     "title": "SDW 2020",
@@ -32,8 +32,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.5437,
-    "y": 0.9641
+    "x": 0.3954,
+    "y": 0.8169
   },
   {
     "title": "git Commands Cheat Sheet",
@@ -44,8 +44,8 @@
     "connected": [
       "block-commit"
     ],
-    "x": 0.9819,
-    "y": 0.8538
+    "x": 0.4034,
+    "y": 0.876
   },
   {
     "title": "rhino3dm",
@@ -57,8 +57,8 @@
       "ghpy-ghuser-compile",
       "rhinomcptest"
     ],
-    "x": 0.6371,
-    "y": 0.9148
+    "x": 0.7057,
+    "y": 0.9458
   },
   {
     "title": ".wslconfig",
@@ -67,8 +67,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.7309,
-    "y": 0.9479
+    "x": 0.5174,
+    "y": 0.8211
   },
   {
     "title": "*.ghpy, *.ghuser compile",
@@ -82,8 +82,8 @@
       "ghpythonutils",
       "rhino3dm"
     ],
-    "x": 0.8481,
-    "y": 0.9137
+    "x": 0.6618,
+    "y": 0.9524
   },
   {
     "title": "Inverse Design",
@@ -96,8 +96,8 @@
       "building-gan",
       "reading-list"
     ],
-    "x": 0.5675,
-    "y": 0.5316
+    "x": 0.7145,
+    "y": 0.3432
   },
   {
     "title": "...",
@@ -106,8 +106,8 @@
     "category": "note",
     "label": "Wordballoon",
     "connected": [],
-    "x": 0.8497,
-    "y": 0.154
+    "x": 0.0949,
+    "y": 0.4465
   },
   {
     "title": "Dot Product",
@@ -118,10 +118,11 @@
     "connected": [
       "cosine-similarity",
       "plane-equation",
-      "intuitive-understanding-of-linear-algebra"
+      "intuitive-understanding-of-linear-algebra",
+      "triangle-menu-aim"
     ],
-    "x": 0.0471,
-    "y": 0.6976
+    "x": 0.7296,
+    "y": 0.5609
   },
   {
     "title": "Non-linearity",
@@ -133,8 +134,8 @@
       "chain-rule",
       "skip-connection"
     ],
-    "x": 0.1709,
-    "y": 0.5068
+    "x": 0.7365,
+    "y": 0.196
   },
   {
     "title": "Chain Rule",
@@ -147,8 +148,8 @@
       "non-linearity",
       "numerical-differentitation-for-autograd"
     ],
-    "x": 0.3167,
-    "y": 0.3704
+    "x": 0.6523,
+    "y": 0.1749
   },
   {
     "title": "Cosine Similarity",
@@ -159,8 +160,8 @@
     "connected": [
       "dot-product"
     ],
-    "x": 0.0789,
-    "y": 0.6749
+    "x": 0.6735,
+    "y": 0.5417
   },
   {
     "title": "Dropout",
@@ -171,8 +172,8 @@
     "connected": [
       "machine-learning-students-overfit-to-overfitting"
     ],
-    "x": 0.3121,
-    "y": 0.4811
+    "x": 0.6689,
+    "y": 0.3173
   },
   {
     "title": "Generative Adversarial Networks",
@@ -186,8 +187,8 @@
       "gradient-penalty",
       "building-gan"
     ],
-    "x": 0.2599,
-    "y": 0.4815
+    "x": 0.8273,
+    "y": 0.0671
   },
   {
     "title": "Optimizers",
@@ -201,8 +202,8 @@
       "gradient-penalty",
       "gradient-accumulation"
     ],
-    "x": 0.2897,
-    "y": 0.3244
+    "x": 0.5819,
+    "y": 0.2469
   },
   {
     "title": "Normalization Layers",
@@ -213,8 +214,8 @@
     "connected": [
       "attention-is-all-you-need"
     ],
-    "x": 0.4526,
-    "y": 0.4214
+    "x": 0.6158,
+    "y": 0.3914
   },
   {
     "title": "super()",
@@ -227,8 +228,8 @@
       "decorator",
       "shapely-geometry-inheritance"
     ],
-    "x": 0.8737,
-    "y": 0.74
+    "x": 0.4554,
+    "y": 0.7575
   },
   {
     "title": "단순함의 법칙",
@@ -239,8 +240,8 @@
     "connected": [
       "good-refactoring-vs-bad-refactoring"
     ],
-    "x": 0.7802,
-    "y": 0.1342
+    "x": 0.1907,
+    "y": 0.4338
   },
   {
     "title": "decorator",
@@ -253,8 +254,8 @@
       "super",
       "inspect-getsource"
     ],
-    "x": 0.8167,
-    "y": 0.7452
+    "x": 0.5383,
+    "y": 0.7179
   },
   {
     "title": "Linear Interpolation",
@@ -266,8 +267,8 @@
       "latent-points",
       "extrapolation"
     ],
-    "x": 0.2466,
-    "y": 0.5564
+    "x": 0.8315,
+    "y": 0.3153
   },
   {
     "title": "mass test",
@@ -279,8 +280,8 @@
       "mass-generator",
       "inverse-design"
     ],
-    "x": 0.3347,
-    "y": 0.9175
+    "x": 0.718,
+    "y": 0.6625
   },
   {
     "title": "Conditional Generative Adversarial Nets",
@@ -293,8 +294,8 @@
       "building-gan",
       "geometric-deep-learning"
     ],
-    "x": 0.4217,
-    "y": 0.5308
+    "x": 0.8185,
+    "y": 0.1523
   },
   {
     "title": "Intersection over Union (IoU)",
@@ -306,8 +307,8 @@
       "metrics",
       "chamfer-distance"
     ],
-    "x": 0.1842,
-    "y": 0.6223
+    "x": 0.7,
+    "y": 0.4777
   },
   {
     "title": "Label Smoothing",
@@ -318,8 +319,8 @@
     "connected": [
       "machine-learning-students-overfit-to-overfitting"
     ],
-    "x": 0.2227,
-    "y": 0.3822
+    "x": 0.6887,
+    "y": 0.3059
   },
   {
     "title": "ChatGPT Custom Instructions",
@@ -328,8 +329,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.7372,
-    "y": 0.3805
+    "x": 0.4811,
+    "y": 0.6432
   },
   {
     "title": "DeepSDF: Learning Continuous Signed Distance Functions for Shape Representation",
@@ -344,8 +345,8 @@
       "poly-inr",
       "representation-learning"
     ],
-    "x": 0.3748,
-    "y": 0.5815
+    "x": 0.7831,
+    "y": 0.2211
   },
   {
     "title": "Skip Connection",
@@ -357,8 +358,8 @@
       "intuition-about-transformer",
       "u-net"
     ],
-    "x": 0.4321,
-    "y": 0.4123
+    "x": 0.5911,
+    "y": 0.2813
   },
   {
     "title": "docker CLI Cheat Sheet",
@@ -367,8 +368,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 1.0,
-    "y": 0.881
+    "x": 0.4833,
+    "y": 0.8597
   },
   {
     "title": "eigenvalues, eigenvectors",
@@ -381,8 +382,8 @@
       "pca",
       "intuitive-understanding-of-linear-algebra"
     ],
-    "x": 0.0095,
-    "y": 0.6586
+    "x": 0.6357,
+    "y": 0.5413
   },
   {
     "title": "Mathematics for Machine Learning",
@@ -395,8 +396,8 @@
       "pca",
       "intuitive-understanding-of-linear-algebra"
     ],
-    "x": 0.066,
-    "y": 0.7149
+    "x": 0.8182,
+    "y": 0.3973
   },
   {
     "title": "Weisfeiler and Leman Go Neural: Higher-order Graph Neural Networks",
@@ -409,8 +410,8 @@
       "voxels-to-graph",
       "building-gan"
     ],
-    "x": 0.4024,
-    "y": 0.4406
+    "x": 0.7876,
+    "y": 0.2227
   },
   {
     "title": "Machine Learning Students Overfit to Overfitting",
@@ -422,8 +423,8 @@
       "dropout",
       "label-smoothing"
     ],
-    "x": 0.4886,
-    "y": 0.3304
+    "x": 0.676,
+    "y": 0.227
   },
   {
     "title": "Metrics",
@@ -435,8 +436,8 @@
       "intersection-over-union-iou",
       "chamfer-distance"
     ],
-    "x": 0.094,
-    "y": 0.5467
+    "x": 0.4802,
+    "y": 0.3963
   },
   {
     "title": "Intuitions about Transformer",
@@ -449,8 +450,8 @@
       "attention-attention",
       "attention-is-all-you-need"
     ],
-    "x": 0.5574,
-    "y": 0.4358
+    "x": 0.6153,
+    "y": 0.2977
   },
   {
     "title": "Attention? Attention!",
@@ -462,8 +463,8 @@
       "intuition-about-transformer",
       "attention-is-all-you-need"
     ],
-    "x": 0.5015,
-    "y": 0.5011
+    "x": 0.7357,
+    "y": 0.2556
   },
   {
     "title": "Attention Is All You Need",
@@ -477,8 +478,8 @@
       "normalization-layers",
       "skip-connection"
     ],
-    "x": 0.4502,
-    "y": 0.4694
+    "x": 0.7217,
+    "y": 0.1813
   },
   {
     "title": "Testing with Github Actions",
@@ -490,8 +491,8 @@
       "pytest-raises",
       "secrets-in-github-actions"
     ],
-    "x": 0.8926,
-    "y": 0.8437
+    "x": 0.5385,
+    "y": 0.9935
   },
   {
     "title": "Linear Algebra for Programmers (프로그래머를 위한 선형대수)",
@@ -505,8 +506,8 @@
       "mathematics-for-machine-learning",
       "pca"
     ],
-    "x": 0.0214,
-    "y": 0.6525
+    "x": 0.8466,
+    "y": 0.3596
   },
   {
     "title": "How to pivot to a Machine Learning engineer?",
@@ -517,8 +518,8 @@
     "connected": [
       "you-are-not-dumb-you-just-lack-the-prerequisites"
     ],
-    "x": 0.5337,
-    "y": 0.3756
+    "x": 0.6949,
+    "y": 0.4154
   },
   {
     "title": "Autoencoder",
@@ -532,8 +533,8 @@
       "exploring-generative-3d-shapes-using-autoencoder-networks",
       "auto-encoding-variational-bayes"
     ],
-    "x": 0.3587,
-    "y": 0.4994
+    "x": 0.7439,
+    "y": 0.1749
   },
   {
     "title": "U-Net: Convolutional Networks for Biomedical Image Segmentation",
@@ -546,8 +547,8 @@
       "skip-connection",
       "intuitions-about-diffusion-models"
     ],
-    "x": 0.4654,
-    "y": 0.5011
+    "x": 0.7785,
+    "y": 0.2731
   },
   {
     "title": "Shapely geometry inheritance",
@@ -558,8 +559,8 @@
     "connected": [
       "super"
     ],
-    "x": 0.4739,
-    "y": 0.9319
+    "x": 0.7815,
+    "y": 0.9009
   },
   {
     "title": "Nausea (구토)",
@@ -573,8 +574,8 @@
       "the-myth-of-sisyphus",
       "words"
     ],
-    "x": 0.9316,
-    "y": 0.0251
+    "x": 0.0594,
+    "y": 0.4986
   },
   {
     "title": "You Are NOT Dumb, You Just Lack the Prerequisites",
@@ -586,8 +587,8 @@
       "how-to-pivot-to-a-machine-learning-engineer",
       "good-refactoring-vs-bad-refactoring"
     ],
-    "x": 0.671,
-    "y": 0.2771
+    "x": 0.4094,
+    "y": 0.5324
   },
   {
     "title": "LDLM",
@@ -600,8 +601,8 @@
       "representation-learning",
       "exploring-generative-3d-shapes-using-autoencoder-networks"
     ],
-    "x": 0.5631,
-    "y": 0.6006
+    "x": 0.7263,
+    "y": 0.4175
   },
   {
     "title": "?",
@@ -610,8 +611,8 @@
     "category": "note",
     "label": "Wordballoon",
     "connected": [],
-    "x": 0.8493,
-    "y": 0.1331
+    "x": 0.1811,
+    "y": 0.3757
   },
   {
     "title": "Setting different learning rates within an optimizer",
@@ -623,8 +624,8 @@
       "optimizers",
       "gradient-accumulation"
     ],
-    "x": 0.2942,
-    "y": 0.3823
+    "x": 0.6688,
+    "y": 0.3779
   },
   {
     "title": "Good Refactoring vs. Bad Refactoring",
@@ -636,8 +637,8 @@
       "you-are-not-dumb-you-just-lack-the-prerequisites",
       "the-laws-of-simplicity"
     ],
-    "x": 0.6509,
-    "y": 0.3075
+    "x": 0.4842,
+    "y": 0.6651
   },
   {
     "title": "중꺾마",
@@ -646,8 +647,8 @@
     "category": "note",
     "label": "Wordballoon",
     "connected": [],
-    "x": 0.9547,
-    "y": 0.1543
+    "x": 0.2433,
+    "y": 0.6221
   },
   {
     "title": "Representation Learning: A Review and New Perspectives",
@@ -660,8 +661,8 @@
       "exploring-generative-3d-shapes-using-autoencoder-networks",
       "auto-encoding-variational-bayes"
     ],
-    "x": 0.4752,
-    "y": 0.3867
+    "x": 0.7143,
+    "y": 0.0
   },
   {
     "title": "Live Preview (ms-vscode.live-server)",
@@ -670,8 +671,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.7428,
-    "y": 0.8375
+    "x": 0.4738,
+    "y": 0.8773
   },
   {
     "title": "Thoughtless Thought",
@@ -680,8 +681,8 @@
     "category": "note",
     "label": "Wordballoon",
     "connected": [],
-    "x": 0.9362,
-    "y": 0.1036
+    "x": 0.1527,
+    "y": 0.4108
   },
   {
     "title": "Math Notation Cheat Sheet",
@@ -693,8 +694,8 @@
       "intuitive-understanding-of-linear-algebra",
       "mathematics-for-machine-learning"
     ],
-    "x": 0.0447,
-    "y": 0.5819
+    "x": 0.741,
+    "y": 0.3107
   },
   {
     "title": "ルックバック (룩백)",
@@ -705,8 +706,8 @@
     "connected": [
       "writes-and-write-not"
     ],
-    "x": 0.3773,
-    "y": 0.283
+    "x": 0.2943,
+    "y": 0.4989
   },
   {
     "title": "Block Commit",
@@ -717,8 +718,8 @@
     "connected": [
       "useful-git-commands"
     ],
-    "x": 0.9381,
-    "y": 0.8239
+    "x": 0.4119,
+    "y": 0.8216
   },
   {
     "title": "哲希",
@@ -727,8 +728,8 @@
     "category": "note",
     "label": "Wordballoon",
     "connected": [],
-    "x": 0.6766,
-    "y": 0.7953
+    "x": 0.3315,
+    "y": 0.7309
   },
   {
     "title": "Siddhartha (싯다르타)",
@@ -742,8 +743,8 @@
       "the-myth-of-sisyphus",
       "words"
     ],
-    "x": 0.8985,
-    "y": 0.0346
+    "x": 0.1,
+    "y": 0.49
   },
   {
     "title": "Bayes'&nbsp Theorem",
@@ -756,8 +757,8 @@
       "maximum-likelihood-estimation",
       "auto-encoding-variational-bayes"
     ],
-    "x": 0.2471,
-    "y": 0.4014
+    "x": 0.4287,
+    "y": 0.3257
   },
   {
     "title": "likelihood",
@@ -770,8 +771,8 @@
       "maximum-likelihood-estimation",
       "regression-model"
     ],
-    "x": 0.1579,
-    "y": 0.4533
+    "x": 0.5962,
+    "y": 0.3932
   },
   {
     "title": "Maximum Likelihood Estimation",
@@ -784,8 +785,8 @@
       "bayes-theorem",
       "regression-model"
     ],
-    "x": 0.1765,
-    "y": 0.4547
+    "x": 0.7362,
+    "y": 0.0722
   },
   {
     "title": "딴 생각",
@@ -796,8 +797,8 @@
     "connected": [
       "siddhartha"
     ],
-    "x": 0.9713,
-    "y": 0.0826
+    "x": 0.0755,
+    "y": 0.4036
   },
   {
     "title": "Polynomial Implicit Neural Representations For Large Diverse Datasets",
@@ -809,8 +810,8 @@
       "inductive-bias",
       "deep-sdf"
     ],
-    "x": 0.4495,
-    "y": 0.4402
+    "x": 0.8012,
+    "y": 0.1712
   },
   {
     "title": "Programmers are like",
@@ -819,8 +820,8 @@
     "category": "note",
     "label": "Eyes",
     "connected": [],
-    "x": 0.6954,
-    "y": 0.2789
+    "x": 0.3727,
+    "y": 0.6411
   },
   {
     "title": "JustMyCode configuration",
@@ -829,8 +830,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.8727,
-    "y": 0.8355
+    "x": 0.3975,
+    "y": 0.8
   },
   {
     "title": "No Exit (닫힌 방)",
@@ -844,8 +845,8 @@
       "the-myth-of-sisyphus",
       "unbearable-lightness-of-being"
     ],
-    "x": 0.9354,
-    "y": 0.0308
+    "x": 0.0968,
+    "y": 0.6189
   },
   {
     "title": "거짓말",
@@ -854,8 +855,8 @@
     "category": "note",
     "label": "Robot",
     "connected": [],
-    "x": 0.7089,
-    "y": 0.1241
+    "x": 0.1731,
+    "y": 0.489
   },
   {
     "title": "Inductive Bias",
@@ -868,8 +869,8 @@
       "poly-inr",
       "extrapolation"
     ],
-    "x": 0.4925,
-    "y": 0.3963
+    "x": 0.6706,
+    "y": 0.034
   },
   {
     "title": "Inductive Bias",
@@ -882,8 +883,8 @@
       "bayes-theorem",
       "extrapolation"
     ],
-    "x": 0.5254,
-    "y": 0.2956
+    "x": 0.537,
+    "y": 0.1685
   },
   {
     "title": "HuggingFace Inference Endpoints",
@@ -892,8 +893,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.4793,
-    "y": 0.5712
+    "x": 0.7195,
+    "y": 0.5069
   },
   {
     "title": "Grandient Accumulation",
@@ -905,8 +906,8 @@
       "data-parallel",
       "optimizers"
     ],
-    "x": 0.3264,
-    "y": 0.3385
+    "x": 0.81,
+    "y": 0.3146
   },
   {
     "title": "Words (말)",
@@ -920,8 +921,8 @@
       "unbearable-lightness-of-being",
       "siddhartha"
     ],
-    "x": 0.8831,
-    "y": 0.0157
+    "x": 0.0,
+    "y": 0.5142
   },
   {
     "title": "Material Masking",
@@ -932,8 +933,8 @@
     "connected": [
       "selectionbox"
     ],
-    "x": 0.5992,
-    "y": 0.8282
+    "x": 0.6606,
+    "y": 0.7304
   },
   {
     "title": "20년 반도체맨이 말하는 삼성전자 위기론",
@@ -944,8 +945,8 @@
     "connected": [
       "human-action"
     ],
-    "x": 0.7452,
-    "y": 0.1084
+    "x": 0.2235,
+    "y": 0.4475
   },
   {
     "title": "Fancy Indexing Cheat Sheet",
@@ -954,8 +955,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.3358,
-    "y": 0.5361
+    "x": 0.7732,
+    "y": 0.51
   },
   {
     "title": "register_buffer",
@@ -966,8 +967,8 @@
     "connected": [
       "data-parallel"
     ],
-    "x": 0.3601,
-    "y": 0.4966
+    "x": 0.6722,
+    "y": 0.4278
   },
   {
     "title": "Free-form Floor Plan Design using Differentiable Voronoi Diagram",
@@ -979,8 +980,8 @@
       "discrete-voronoi",
       "floor-plan-generation-with-voronoi-diagram"
     ],
-    "x": 0.3823,
-    "y": 0.7972
+    "x": 0.9441,
+    "y": 0.6789
   },
   {
     "title": "nohup",
@@ -989,8 +990,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.871,
-    "y": 0.8931
+    "x": 0.4497,
+    "y": 0.8656
   },
   {
     "title": "About Behaviorism (스키너의 행동심리학)",
@@ -1002,8 +1003,8 @@
       "human-action",
       "we-are-being-programmed"
     ],
-    "x": 0.7956,
-    "y": 0.0464
+    "x": 0.1283,
+    "y": 0.3748
   },
   {
     "title": "Writes and Write-Nots",
@@ -1016,8 +1017,8 @@
       "qq",
       "capability-overhang"
     ],
-    "x": 0.7029,
-    "y": 0.2561
+    "x": 0.3415,
+    "y": 0.444
   },
   {
     "title": "numerical differentiation for autograd",
@@ -1030,8 +1031,8 @@
       "regression-model",
       "mathematics-for-machine-learning"
     ],
-    "x": 0.2594,
-    "y": 0.333
+    "x": 0.7192,
+    "y": 0.3608
   },
   {
     "title": "雪国 (설국)",
@@ -1042,8 +1043,8 @@
     "connected": [
       "no-longer-human"
     ],
-    "x": 0.9467,
-    "y": 0.0643
+    "x": 0.1669,
+    "y": 0.5388
   },
   {
     "title": "Python Slack SDK",
@@ -1052,8 +1053,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.6474,
-    "y": 0.7338
+    "x": 0.6016,
+    "y": 0.8695
   },
   {
     "title": "Chamfer Distance",
@@ -1065,8 +1066,8 @@
       "intersection-over-union-iou",
       "metrics"
     ],
-    "x": 0.1315,
-    "y": 0.6717
+    "x": 0.7689,
+    "y": 0.6589
   },
   {
     "title": "Wedbush Top 10 Christmas Wish List for the Tech Sector in 2025",
@@ -1075,8 +1076,8 @@
     "category": "note",
     "label": "Eyes",
     "connected": [],
-    "x": 0.6039,
-    "y": 0.9894
+    "x": 0.4779,
+    "y": 0.8001
   },
   {
     "title": "Auto-Encoding Variational Bayes",
@@ -1091,8 +1092,8 @@
       "bayes-theorem",
       "maximum-likelihood-estimation"
     ],
-    "x": 0.2913,
-    "y": 0.432
+    "x": 0.7556,
+    "y": 0.0614
   },
   {
     "title": "KL-Divergence",
@@ -1105,8 +1106,8 @@
       "wasserstein-distance",
       "intuitions-about-diffusion-models"
     ],
-    "x": 0.1267,
-    "y": 0.5817
+    "x": 0.6086,
+    "y": 0.3325
   },
   {
     "title": "Hallucination is a feature not a bug",
@@ -1118,8 +1119,8 @@
       "writes-and-write-not",
       "capability-overhang"
     ],
-    "x": 0.6489,
-    "y": 0.3841
+    "x": 0.447,
+    "y": 0.4093
   },
   {
     "title": "The Myth of Sisyphus (시지프 신화)",
@@ -1133,8 +1134,8 @@
       "unbearable-lightness-of-being",
       "no-longer-human"
     ],
-    "x": 0.8398,
-    "y": 0.0149
+    "x": 0.0163,
+    "y": 0.5307
   },
   {
     "title": "DataParallel",
@@ -1147,8 +1148,8 @@
       "register_buffer",
       "nvitop"
     ],
-    "x": 0.3918,
-    "y": 0.6999
+    "x": 0.8966,
+    "y": 0.5741
   },
   {
     "title": "ghdoc.Path",
@@ -1161,8 +1162,8 @@
       "ghpy-ghuser-compile",
       "scriptcontext-sticky"
     ],
-    "x": 0.8207,
-    "y": 0.9377
+    "x": 0.596,
+    "y": 0.9969
   },
   {
     "title": "Human Action (인간 행동)",
@@ -1175,8 +1176,8 @@
       "about-behaviorism",
       "truth"
     ],
-    "x": 0.7429,
-    "y": 0.0937
+    "x": 0.1808,
+    "y": 0.362
   },
   {
     "title": "Building-GAN: Graph-Conditioned Architectural Volumetric Design Generation",
@@ -1191,8 +1192,8 @@
       "gumbel-softmax",
       "message-passing"
     ],
-    "x": 0.4376,
-    "y": 0.672
+    "x": 0.9763,
+    "y": 0.5333
   },
   {
     "title": "pytest.raises",
@@ -1204,8 +1205,8 @@
       "testing-with-github-actions",
       "inspect-getsource"
     ],
-    "x": 0.7842,
-    "y": 0.7019
+    "x": 0.5309,
+    "y": 0.7522
   },
   {
     "title": "scriptcontext.sticky",
@@ -1218,8 +1219,8 @@
       "indexed-db",
       "ghdoc"
     ],
-    "x": 0.8633,
-    "y": 0.9406
+    "x": 0.4432,
+    "y": 0.8407
   },
   {
     "title": "Message Passing",
@@ -1232,8 +1233,8 @@
       "building-gan",
       "geometric-deep-learning"
     ],
-    "x": 0.3839,
-    "y": 0.3945
+    "x": 0.7762,
+    "y": 0.4198
   },
   {
     "title": "w를 찾아서",
@@ -1242,8 +1243,8 @@
     "category": "note",
     "label": "Eyes",
     "connected": [],
-    "x": 0.8642,
-    "y": 0.1716
+    "x": 0.274,
+    "y": 0.5852
   },
   {
     "title": "Gumbel-Softmax",
@@ -1255,8 +1256,8 @@
       "building-gan",
       "auto-encoding-variational-bayes"
     ],
-    "x": 0.2393,
-    "y": 0.427
+    "x": 0.7559,
+    "y": 0.2526
   },
   {
     "title": "??",
@@ -1270,8 +1271,8 @@
       "we-are-being-programmed",
       "writes-and-write-not"
     ],
-    "x": 0.6954,
-    "y": 0.162
+    "x": 0.3413,
+    "y": 0.3624
   },
   {
     "title": "Wasserstein Distance (Earth Mover's Distance)",
@@ -1284,8 +1285,8 @@
       "gradient-penalty",
       "kl-divergence"
     ],
-    "x": 0.1992,
-    "y": 0.601
+    "x": 0.7547,
+    "y": 0.3045
   },
   {
     "title": "Gradient Penalty",
@@ -1297,8 +1298,8 @@
       "wasserstein-distance",
       "gan"
     ],
-    "x": 0.2783,
-    "y": 0.3436
+    "x": 0.7429,
+    "y": 0.2949
   },
   {
     "title": "Discrete Voronoi",
@@ -1311,8 +1312,8 @@
       "free-form-floor-plan-design-using-differentiable-voronoi-diagram",
       "floor-plan-generation-with-voronoi-diagram"
     ],
-    "x": 0.4319,
-    "y": 0.7782
+    "x": 0.8203,
+    "y": 0.6089
   },
   {
     "title": "we are being programmed",
@@ -1326,8 +1327,8 @@
       "about-behaviorism",
       "qq"
     ],
-    "x": 0.7149,
-    "y": 0.2613
+    "x": 0.4879,
+    "y": 0.4979
   },
   {
     "title": "Two Points Perspective in threejs",
@@ -1340,8 +1341,8 @@
       "plane-equation",
       "local-coordinate-system"
     ],
-    "x": 0.1993,
-    "y": 0.8127
+    "x": 0.6156,
+    "y": 0.7569
   },
   {
     "title": "면도날",
@@ -1354,8 +1355,8 @@
       "no-longer-human",
       "the-myth-of-sisyphus"
     ],
-    "x": 0.9522,
-    "y": 0.0488
+    "x": 0.1253,
+    "y": 0.5755
   },
   {
     "title": "Half-Plane Clipping",
@@ -1366,10 +1367,11 @@
     "connected": [
       "plane-equation",
       "dot-product",
-      "subdivision-curve"
+      "subdivision-curve",
+      "triangle-menu-aim"
     ],
-    "x": 0.1967,
-    "y": 0.8358
+    "x": 0.7759,
+    "y": 0.7804
   },
   {
     "title": "Exploring Generative 3D Shapes Using Autoencoder Networks",
@@ -1383,8 +1385,8 @@
       "representation-learning",
       "latent-shapes"
     ],
-    "x": 0.4011,
-    "y": 0.634
+    "x": 0.9361,
+    "y": 0.4133
   },
   {
     "title": "4o Image Generation",
@@ -1393,8 +1395,8 @@
     "category": "note",
     "label": "Eyes",
     "connected": [],
-    "x": 0.5849,
-    "y": 0.513
+    "x": 0.5794,
+    "y": 0.4748
   },
   {
     "title": "MCP-related",
@@ -1407,8 +1409,8 @@
       "rhinomcptest",
       "claude-code-cheat-sheet"
     ],
-    "x": 0.8201,
-    "y": 0.7064
+    "x": 0.6155,
+    "y": 0.7023
   },
   {
     "title": "extrapolation",
@@ -1421,8 +1423,8 @@
       "inductive-bias-2",
       "poly-inr"
     ],
-    "x": 0.4622,
-    "y": 0.3401
+    "x": 0.6772,
+    "y": 0.1418
   },
   {
     "title": "Latent Points",
@@ -1436,8 +1438,8 @@
       "linear-interpolation",
       "exploring-generative-3d-shapes-using-autoencoder-networks"
     ],
-    "x": 0.3437,
-    "y": 0.7052
+    "x": 0.8835,
+    "y": 0.5571
   },
   {
     "title": "OpenAI Agents SDK",
@@ -1450,8 +1452,8 @@
       "metaclass",
       "inspect-getsource"
     ],
-    "x": 0.7509,
-    "y": 0.6752
+    "x": 0.7872,
+    "y": 0.8029
   },
   {
     "title": "참을 수 없는 존재의 가벼움",
@@ -1466,8 +1468,8 @@
       "no-exit",
       "words"
     ],
-    "x": 0.8461,
-    "y": 0.0219
+    "x": 0.0512,
+    "y": 0.4236
   },
   {
     "title": "secrets in Github Actions",
@@ -1478,8 +1480,8 @@
     "connected": [
       "testing-with-github-actions"
     ],
-    "x": 0.9371,
-    "y": 0.8395
+    "x": 0.4154,
+    "y": 0.8257
   },
   {
     "title": "Github PR Suggestion",
@@ -1488,8 +1490,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.7544,
-    "y": 0.8001
+    "x": 0.476,
+    "y": 0.8094
   },
   {
     "title": "metaclass",
@@ -1502,8 +1504,8 @@
       "decorator",
       "super"
     ],
-    "x": 0.8157,
-    "y": 0.6837
+    "x": 0.5823,
+    "y": 0.6742
   },
   {
     "title": "truth",
@@ -1516,8 +1518,8 @@
       "we-are-being-programmed",
       "qq"
     ],
-    "x": 0.7086,
-    "y": 0.1699
+    "x": 0.2666,
+    "y": 0.3824
   },
   {
     "title": "PyO3",
@@ -1528,8 +1530,8 @@
     "connected": [
       "wasm"
     ],
-    "x": 0.6706,
-    "y": 0.8961
+    "x": 0.5669,
+    "y": 0.9673
   },
   {
     "title": "AI의 진짜 똑똑함을 우리는 아직 모른다",
@@ -1543,8 +1545,8 @@
       "we-are-being-programmed",
       "writes-and-write-not"
     ],
-    "x": 0.7115,
-    "y": 0.2056
+    "x": 0.3061,
+    "y": 0.345
   },
   {
     "title": "inspect.getsource",
@@ -1557,8 +1559,8 @@
       "pytest-raises",
       "decorator"
     ],
-    "x": 0.8557,
-    "y": 0.728
+    "x": 0.5147,
+    "y": 0.8383
   },
   {
     "title": "SelectionBox",
@@ -1570,8 +1572,8 @@
       "three-geometries",
       "material-masking"
     ],
-    "x": 0.6061,
-    "y": 0.8596
+    "x": 0.5893,
+    "y": 0.8857
   },
   {
     "title": "asdf",
@@ -1580,8 +1582,8 @@
     "category": "note",
     "label": "Wordballoon",
     "connected": [],
-    "x": 0.935,
-    "y": 0.1426
+    "x": 0.1529,
+    "y": 0.4928
   },
   {
     "title": "인간 실격",
@@ -1595,8 +1597,8 @@
       "nausea",
       "siddhartha"
     ],
-    "x": 0.8736,
-    "y": 0.0
+    "x": 0.0108,
+    "y": 0.5489
   },
   {
     "title": "LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models",
@@ -1609,8 +1611,8 @@
       "floor-plan-generation-with-voronoi-diagram",
       "building-gan"
     ],
-    "x": 0.5897,
-    "y": 0.6349
+    "x": 0.692,
+    "y": 0.4313
   },
   {
     "title": "nvitop",
@@ -1621,8 +1623,8 @@
     "connected": [
       "data-parallel"
     ],
-    "x": 0.829,
-    "y": 0.8849
+    "x": 0.5335,
+    "y": 0.7428
   },
   {
     "title": "Principal Component Analysis",
@@ -1636,8 +1638,8 @@
       "intuitive-understanding-of-linear-algebra",
       "standardization"
     ],
-    "x": 0.0,
-    "y": 0.6569
+    "x": 0.8192,
+    "y": 0.5343
   },
   {
     "title": "wsic",
@@ -1646,8 +1648,8 @@
     "category": "note",
     "label": "Wordballoon",
     "connected": [],
-    "x": 0.575,
-    "y": 0.9695
+    "x": 0.3763,
+    "y": 0.8545
   },
   {
     "title": "Plane Equation",
@@ -1661,8 +1663,8 @@
       "local-coordinate-system",
       "dot-product"
     ],
-    "x": 0.0775,
-    "y": 0.7652
+    "x": 0.7025,
+    "y": 0.6637
   },
   {
     "title": "rhinomcptest",
@@ -1674,8 +1676,8 @@
       "mcp-related",
       "rhino3dm"
     ],
-    "x": 0.5813,
-    "y": 0.9634
+    "x": 0.4625,
+    "y": 0.9922
   },
   {
     "title": "2025 Google Search Console Report",
@@ -1684,8 +1686,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.6186,
-    "y": 0.9781
+    "x": 0.494,
+    "y": 0.857
   },
   {
     "title": "standardization",
@@ -1697,8 +1699,8 @@
       "regression-model",
       "pca"
     ],
-    "x": 0.064,
-    "y": 0.5559
+    "x": 0.6563,
+    "y": 0.4574
   },
   {
     "title": "q-sample",
@@ -1710,8 +1712,8 @@
       "intuitions-about-diffusion-models",
       "standardization"
     ],
-    "x": 0.7204,
-    "y": 0.775
+    "x": 0.5677,
+    "y": 0.7597
   },
   {
     "title": "ssh-keygen shortcut",
@@ -1720,8 +1722,8 @@
     "category": "note",
     "label": "Note",
     "connected": [],
-    "x": 0.9536,
-    "y": 0.8314
+    "x": 0.3628,
+    "y": 0.8319
   },
   {
     "title": "StyleID: A Perception-Aware Dataset and Metric for Stylization-Agnostic Facial Identity Recognition",
@@ -1730,8 +1732,8 @@
     "category": "note",
     "label": "Brain",
     "connected": [],
-    "x": 0.5276,
-    "y": 0.5751
+    "x": 0.6227,
+    "y": 0.4801
   },
   {
     "title": "ego",
@@ -1742,8 +1744,8 @@
     "connected": [
       "capability-overhang"
     ],
-    "x": 0.7576,
-    "y": 0.226
+    "x": 0.2162,
+    "y": 0.4046
   },
   {
     "title": "Distorted Grid Graph",
@@ -1752,8 +1754,8 @@
     "category": "note",
     "label": "Storm",
     "connected": [],
-    "x": 0.4908,
-    "y": 0.7997
+    "x": 0.6377,
+    "y": 0.7867
   },
   {
     "title": "Intuitions about Diffusion Models",
@@ -1767,8 +1769,8 @@
       "kl-divergence",
       "q-sample"
     ],
-    "x": 0.1486,
-    "y": 0.4681
+    "x": 0.6425,
+    "y": 0.2569
   },
   {
     "title": "전력 질주",
@@ -1777,8 +1779,8 @@
     "category": "note",
     "label": "Wordballoon",
     "connected": [],
-    "x": 0.8096,
-    "y": 0.0646
+    "x": 0.1349,
+    "y": 0.4358
   },
   {
     "title": "Claude Code Cheat Sheet",
@@ -1789,8 +1791,8 @@
     "connected": [
       "mcp-related"
     ],
-    "x": 0.997,
-    "y": 0.8671
+    "x": 0.4081,
+    "y": 0.8745
   },
   {
     "title": "WASM",
@@ -1802,8 +1804,8 @@
       "indexed-db",
       "pyo3"
     ],
-    "x": 0.6891,
-    "y": 0.9268
+    "x": 0.5788,
+    "y": 0.7467
   },
   {
     "title": "Regression Model",
@@ -1817,8 +1819,8 @@
       "likelihood",
       "maximum-likelihood-estimation"
     ],
-    "x": 0.1436,
-    "y": 0.4614
+    "x": 0.7386,
+    "y": 0.3342
   },
   {
     "title": "IndexedDB",
@@ -1830,8 +1832,21 @@
       "wasm",
       "scriptcontext-sticky"
     ],
-    "x": 0.7011,
-    "y": 0.9194
+    "x": 0.5355,
+    "y": 0.7578
+  },
+  {
+    "title": "Triangle Menu-Aim",
+    "slug": "triangle-menu-aim",
+    "url": "/triangle-menu-aim/",
+    "category": "note",
+    "label": "Note",
+    "connected": [
+      "dot-product",
+      "half-plane-clipping"
+    ],
+    "x": 0.6873,
+    "y": 0.713
   },
   {
     "title": "Secure room in seoul",
@@ -1844,8 +1859,8 @@
       "mass-generator",
       "plot-shape-estimator"
     ],
-    "x": 0.4382,
-    "y": 0.84
+    "x": 0.5775,
+    "y": 0.8622
   },
   {
     "title": "Travelling salesman problem",
@@ -1858,8 +1873,8 @@
       "tower-crane-arrangement",
       "the-selfish-gene"
     ],
-    "x": 0.4947,
-    "y": 0.7046
+    "x": 0.7459,
+    "y": 0.6164
   },
   {
     "title": "Mass generator",
@@ -1873,8 +1888,8 @@
       "tower-crane-arrangement",
       "synthesized-skyscrapers"
     ],
-    "x": 0.4332,
-    "y": 0.7567
+    "x": 0.8553,
+    "y": 0.8584
   },
   {
     "title": "Theater sightlines",
@@ -1887,8 +1902,8 @@
       "tower-crane-arrangement",
       "space-syntax"
     ],
-    "x": 0.3506,
-    "y": 0.8529
+    "x": 0.7422,
+    "y": 0.7823
   },
   {
     "title": "Tower crane arrangement",
@@ -1903,8 +1918,8 @@
       "travelling-salesman-problem",
       "mass-generator"
     ],
-    "x": 0.3332,
-    "y": 0.8783
+    "x": 0.8037,
+    "y": 0.8051
   },
   {
     "title": "Space syntax",
@@ -1918,8 +1933,8 @@
       "apartment",
       "floor-plan-generation-with-voronoi-diagram"
     ],
-    "x": 0.4087,
-    "y": 0.9521
+    "x": 0.8299,
+    "y": 0.9866
   },
   {
     "title": "Subdivision curve",
@@ -1932,8 +1947,8 @@
       "quadtree",
       "merry-christmass"
     ],
-    "x": 0.3556,
-    "y": 0.991
+    "x": 0.7387,
+    "y": 0.7346
   },
   {
     "title": "Dynamic mesh fence",
@@ -1944,8 +1959,8 @@
     "connected": [
       "klemens-torggler-door"
     ],
-    "x": 0.4485,
-    "y": 0.9586
+    "x": 0.7616,
+    "y": 0.9015
   },
   {
     "title": "Merry christmas",
@@ -1957,8 +1972,8 @@
       "quadtree",
       "subdivision-curve"
     ],
-    "x": 0.4052,
-    "y": 1.0
+    "x": 0.7328,
+    "y": 0.8022
   },
   {
     "title": "Plot shape estimator",
@@ -1972,8 +1987,8 @@
       "apartment",
       "secure-room-in-seoul"
     ],
-    "x": 0.4049,
-    "y": 0.6854
+    "x": 0.8259,
+    "y": 0.6224
   },
   {
     "title": "Voxelate",
@@ -1987,8 +2002,8 @@
       "mass-gans",
       "wave-function-collapse"
     ],
-    "x": 0.3959,
-    "y": 0.8207
+    "x": 0.898,
+    "y": 0.819
   },
   {
     "title": "Windows placement helper",
@@ -2000,8 +2015,8 @@
       "p2m",
       "three-loaders"
     ],
-    "x": 0.3418,
-    "y": 0.8686
+    "x": 0.7153,
+    "y": 0.9234
   },
   {
     "title": "three.js geoms",
@@ -2014,8 +2029,8 @@
       "two-points-perspective",
       "selectionbox"
     ],
-    "x": 0.6147,
-    "y": 0.8911
+    "x": 0.734,
+    "y": 0.983
   },
   {
     "title": "ghpythonutils",
@@ -2028,8 +2043,8 @@
       "ghdoc",
       "scriptcontext-sticky"
     ],
-    "x": 0.8225,
-    "y": 0.955
+    "x": 0.7103,
+    "y": 0.994
   },
   {
     "title": "Loading the geometries I have",
@@ -2042,8 +2057,8 @@
       "windows-placement-helper",
       "p2m"
     ],
-    "x": 0.4324,
-    "y": 0.9215
+    "x": 0.7255,
+    "y": 1.0
   },
   {
     "title": "K-Rooms clusters",
@@ -2057,8 +2072,8 @@
       "apartment",
       "polygon-segmentation"
     ],
-    "x": 0.3953,
-    "y": 0.8879
+    "x": 0.8557,
+    "y": 0.8155
   },
   {
     "title": "Quadtree",
@@ -2070,8 +2085,8 @@
       "merry-christmass",
       "subdivision-curve"
     ],
-    "x": 0.372,
-    "y": 0.9995
+    "x": 0.8055,
+    "y": 0.8865
   },
   {
     "title": "Klemens Torggler's door",
@@ -2082,8 +2097,8 @@
     "connected": [
       "dynamic-mesh-fence"
     ],
-    "x": 0.4656,
-    "y": 0.8716
+    "x": 0.6285,
+    "y": 0.8132
   },
   {
     "title": "Plan to Model",
@@ -2096,8 +2111,8 @@
       "three-loaders",
       "apartment"
     ],
-    "x": 0.2936,
-    "y": 0.8234
+    "x": 0.9343,
+    "y": 0.8302
   },
   {
     "title": "Analysis of Apt state-spaces",
@@ -2111,8 +2126,8 @@
       "polygon-segmentation",
       "office-layout-generation-agents"
     ],
-    "x": 0.2981,
-    "y": 0.9001
+    "x": 0.831,
+    "y": 0.8762
   },
   {
     "title": "Drafting with AI",
@@ -2126,8 +2141,8 @@
       "synthesized-skyscrapers",
       "latent-shapes"
     ],
-    "x": 0.5816,
-    "y": 0.8474
+    "x": 0.7696,
+    "y": 0.8707
   },
   {
     "title": "Parallel execution within GhPython",
@@ -2138,8 +2153,8 @@
     "connected": [
       "ghpythonutils"
     ],
-    "x": 0.4512,
-    "y": 0.9878
+    "x": 0.8337,
+    "y": 0.8178
   },
   {
     "title": "The selfish gene",
@@ -2150,8 +2165,8 @@
     "connected": [
       "travelling-salesman-problem"
     ],
-    "x": 0.5252,
-    "y": 0.6546
+    "x": 0.5623,
+    "y": 0.553
   },
   {
     "title": "Mass GANs",
@@ -2166,8 +2181,8 @@
       "synthesized-skyscrapers",
       "building-gan"
     ],
-    "x": 0.4944,
-    "y": 0.6211
+    "x": 0.9644,
+    "y": 0.4173
   },
   {
     "title": "Local coordinate system",
@@ -2182,8 +2197,8 @@
       "half-plane-clipping",
       "plane-equation"
     ],
-    "x": 0.1319,
-    "y": 0.8042
+    "x": 0.8853,
+    "y": 0.783
   },
   {
     "title": "Shape-conditional GANs",
@@ -2198,8 +2213,8 @@
       "building-gan",
       "message-passing"
     ],
-    "x": 0.4395,
-    "y": 0.6273
+    "x": 0.9759,
+    "y": 0.4419
   },
   {
     "title": "Seeing is solving",
@@ -2208,8 +2223,8 @@
     "category": "testbed",
     "label": "Testbed",
     "connected": [],
-    "x": 0.776,
-    "y": 0.8429
+    "x": 0.6609,
+    "y": 0.898
   },
   {
     "title": "Infinite synthesis",
@@ -2224,8 +2239,8 @@
       "landbook-diffusion-pipeline",
       "drafting-with-ai"
     ],
-    "x": 0.4723,
-    "y": 0.7058
+    "x": 0.9146,
+    "y": 0.5614
   },
   {
     "title": "Landbook Rendering with Diffuser",
@@ -2237,8 +2252,8 @@
       "landbook-diffusion-pipeline",
       "drafting-with-ai"
     ],
-    "x": 0.6426,
-    "y": 0.7801
+    "x": 0.7143,
+    "y": 0.7543
   },
   {
     "title": "Polygon segmentations",
@@ -2252,8 +2267,8 @@
       "voxels-to-graph",
       "local-coordinate-system"
     ],
-    "x": 0.4167,
-    "y": 0.6341
+    "x": 0.9576,
+    "y": 0.4434
   },
   {
     "title": "Floor Plan Generation with Voronoi Diagram",
@@ -2268,8 +2283,8 @@
       "free-form-floor-plan-design-using-differentiable-voronoi-diagram",
       "discrete-voronoi"
     ],
-    "x": 0.3545,
-    "y": 0.7922
+    "x": 0.9483,
+    "y": 0.6465
   },
   {
     "title": "Landbook Diffusion Pipeline",
@@ -2282,8 +2297,8 @@
       "drafting-with-ai",
       "synthesized-skyscrapers"
     ],
-    "x": 0.5972,
-    "y": 0.7531
+    "x": 0.8328,
+    "y": 0.7655
   },
   {
     "title": "Voxels to Graph",
@@ -2298,8 +2313,8 @@
       "floor-plan-generation-with-voronoi-diagram",
       "building-gan"
     ],
-    "x": 0.5465,
-    "y": 0.6659
+    "x": 1.0,
+    "y": 0.505
   },
   {
     "title": "Office Layout Generation Agents",
@@ -2313,8 +2328,8 @@
       "voxels-to-graph",
       "layout-vlm"
     ],
-    "x": 0.643,
-    "y": 0.6497
+    "x": 0.9091,
+    "y": 0.6085
   },
   {
     "title": "Latent Shapes",
@@ -2329,8 +2344,8 @@
       "latent-points",
       "image-to-3d-scene"
     ],
-    "x": 0.5027,
-    "y": 0.6914
+    "x": 0.9402,
+    "y": 0.5815
   },
   {
     "title": "Wave Function Collapse",
@@ -2342,8 +2357,8 @@
       "floor-plan-generation-with-voronoi-diagram",
       "voxelate"
     ],
-    "x": 0.4388,
-    "y": 0.8651
+    "x": 0.7432,
+    "y": 0.7766
   },
   {
     "title": "Image to 3D Scene Pipeline",
@@ -2357,7 +2372,7 @@
       "mass-gans",
       "local-coordinate-system"
     ],
-    "x": 0.5025,
-    "y": 0.7475
+    "x": 0.9022,
+    "y": 0.6846
   }
 ]


### PR DESCRIPTION
## Summary
- Replace UMAP with PCA to fix numba JIT errors in CI and make coordinates fully deterministic
- Cache OpenAI embeddings in `data/embeddings.json` — only new posts hit the API
- Fix bug: stale cache entries now pruned even when no new posts are added
- Add 10 unit tests guarding against unnecessary API calls

## Why
UMAP + numba kept failing in CI (`IndexError: pop from empty list` in numba's byteflow.py) across PRs #31, #32, #34. `NUMBA_DISABLE_JIT=1` and version pinning both failed. PCA removes the numba dependency entirely while providing:
- Deterministic output (same input → identical coords)
- Minimal coordinate shift when adding posts (~0.2% avg)
- Explained variance ~12% (6.6% + 5.5%) — sufficient for semantic clustering

## Test plan
- [x] 10 pytest tests pass locally (cache skip, pruning, determinism, corrupt cache, consecutive runs)
- [ ] Verify CI workflow passes (no more numba errors)
- [ ] Visual check: latentspace map renders correctly with PCA coords

🤖 Generated with [Claude Code](https://claude.com/claude-code)