### PR TITLE
Improve latentspace initial layout

### DIFF
--- a/js/latentspace.js
+++ b/js/latentspace.js
@@ -23,7 +23,7 @@ function init_latentspace() {
     };
 
     const BASE_RADIUS = 3;
-    const MIN_ZOOM = 0.8;
+    const MIN_ZOOM = 0.9;
     const MAX_ZOOM = 5;
     const VIEWPORT_PAD = 100;
     const IDLE_DELAY = 4000;
@@ -443,7 +443,11 @@ function init_latentspace() {
                 .on("drag", on_drag)
                 .on("end", drag_ended));
 
-        set_initial_min_zoom();
+        simulation.stop();
+        for (var i = 0; i < 300; i++) simulation.tick();
+        on_tick();
+        simulation.restart();
+        fit_all(0);
 
         // --- Mouse interaction ---
 
@@ -730,7 +734,7 @@ function init_latentspace() {
             simulation.force("y").y(function(d) { return d.ty; });
             simulation.alphaTarget(0).alpha(0.35).restart();
             on_tick();
-            set_initial_min_zoom();
+            fit_all(0);
         }
 
         // --- Drag ---


### PR DESCRIPTION
## Summary
- Pre-run 300 simulation ticks before rendering to eliminate initial jittery animation
- Replace `set_initial_min_zoom` with `fit_all` for consistent viewport fitting
- Adjust `MIN_ZOOM` from 0.8 to 0.9

## Test plan
- [ ] Open the latentspace page and verify nodes appear in stable positions without jitter
- [ ] Verify zoom/pan behavior works correctly with the new MIN_ZOOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)