### PR TITLE
Remove ineffective PostToolUse:Edit hook from /add-related

### DIFF
--- a/.claude/skills/add-related/SKILL.md
+++ b/.claude/skills/add-related/SKILL.md
@@ -3,16 +3,6 @@ name: add-related
 description: Add or update related frontmatter for blog posts in note/_posts and testbed/_posts. Supports a full-site pass (--all=true, default) or a single-post focus pass (--post-name=<slug>). Run when user wants to refresh related post links.
 user-invocable: true
 allowed-tools: "Read Edit Bash Glob Grep"
-hooks:
-  PostToolUse:
-    - matcher: "Edit"
-      hooks:
-        - type: prompt
-          prompt: |
-            Check if the edit just made correctly modifies the `related:` frontmatter in a blog post.
-            The related field must be a YAML list with MIN_RELATED to MAX_RELATED slug items (see scripts/config.py for values).
-            Only check the YAML structure and count. Do NOT try to verify whether slugs exist — the verification script handles that.
-            If the structure or count looks wrong, say BLOCK and explain why. Otherwise say ALLOW.
 ---
 
 # Add Related Posts


### PR DESCRIPTION
## Summary
- The PostToolUse:Edit prompt-hook on `/add-related` halted continuation on every blog-post Edit with a message like *"Cannot determine if the related field count is valid because MIN_RELATED and MAX_RELATED values from scripts/config.py are not provided in the context"*. Prompt hooks have no filesystem access, so the values it was told to consult were unreachable by design.
- Count and YAML structure are already validated end-of-run by Step 6 `verify_related.py`, so the hook was redundant on top of being broken.
- Drop the entire `hooks:` block from the SKILL frontmatter.

## Test plan
- [ ] Run `/add-related` (or any Edit on a `note/_posts/*.html` / `testbed/_posts/*.html` frontmatter) and confirm no PostToolUse stop-continuation message appears.
- [ ] Run `python3 .claude/skills/add-related/scripts/verify_related.py` and confirm it still catches missing/over-MAX_RELATED `related:` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)