### PR TITLE
Add /write-post skill for drafting blog posts

### DIFF
--- a/.agents/shared/skills/README.md
+++ b/.agents/shared/skills/README.md
@@ -10,6 +10,7 @@ Available skills:
 
 - `add-related`
 - `build-latentspace`
+- `write-post`
 
 If a skill is invoked but not shown in the active tool's skill list, open the
 matching `SKILL.md` in this directory and follow it manually. Keep shared skills

--- a/.agents/shared/skills/write-post/SKILL.md
+++ b/.agents/shared/skills/write-post/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write-post
 description: Scaffold and draft a new blog post under note/_posts or testbed/_posts following this repo's frontmatter, body-style, image, and follow-up conventions. Use when the user asks to write a post, draft a post, or expand a topic into a post.
-argument-hint: "[topic] [--language=en|kr] [--emoji=<file>] [--sources=<urls,paths>] [--category=note|testbed] [--slug=<slug>]"
+argument-hint: "[topic] [--language=en|kr] [--emoji=<file>] [--sources=<urls,paths>] [--category=note|testbed] [--slug=<slug>] [--at=<venue>]"
 user-invocable: true
 allowed-tools: "Read Write Edit Bash Glob Grep WebFetch"
 ---
@@ -17,10 +17,11 @@ Parse the slash-command `ARGUMENTS:` line for the following flags. All optional.
 | Flag | Values | Default | Meaning |
 |---|---|---|---|
 | `--language` | `en` / `kr` | `en` | Body language. `en` = English, `kr` = Korean. |
-| `--emoji` | filename under `emoji/` (e.g. `brain.png`) or full path (e.g. `/emoji/brain.png`) | _(none)_ | Sets the `emoji:` frontmatter field. If omitted, the field is **not** generated. |
+| `--emoji` | One of `brain.png`, `books.png`, `pin.png`, `eyes.png`, `wordballoon-with-dots.png`, `robot.png`, `storm.png` (or the same with `/emoji/` prefix) | _(none)_ | Sets the `emoji:` frontmatter field. **Only the seven emojis listed have label mappings in `build-latentspace`** — others silently fall back to "Note". If none fits, omit the flag. Full table: `references/frontmatter.md`. |
 | `--sources` | comma-separated list of URLs and/or local file paths | _(none)_ | Reference material. URLs are fetched via `WebFetch`; local paths are read with `Read`. |
 | `--category` | `note` / `testbed` | _(ask)_ | Skip if not provided — always confirm with `AskUserQuestion`. |
 | `--slug` | kebab-case slug | _(derive + confirm)_ | Filename slug without date prefix or extension. |
+| `--at` | venue / lab / event string (testbed only) | _(none)_ | **Do not pass an empty string.** Liquid treats `""` as truthy and renders a dangling `＠` marker in the testbed index. Omit the flag if there is no venue. Known special-cased values with link templates: `Visual Media Lab`, `Spacewalk`. |
 
 A free-text topic (anything in `ARGUMENTS:` outside the flags) is treated as the topic seed.
 
@@ -106,8 +107,11 @@ python3 "$SKILL_DIR/scripts/new_post.py" \
   --title "${TITLE}" \
   --style "${STYLE}" \
   ${EMOJI:+--emoji "$EMOJI"} \
-  ${LANGUAGE:+--language "$LANGUAGE"}
+  ${LANGUAGE:+--language "$LANGUAGE"} \
+  ${AT:+--at "$AT"}
 ```
+
+`--at` only applies to `--category=testbed` and **only** when there is a real venue. If the user did not pass `--at`, do not synthesise an empty value — the script omits the field entirely, which is the only safe behaviour given Liquid's truthiness rules.
 
 The script writes `<category>/_posts/<date>-<slug>.html` and prints the path. It also creates `img/<slug>/` ahead of any diagram work.
 

--- a/.agents/shared/skills/write-post/SKILL.md
+++ b/.agents/shared/skills/write-post/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write-post
 description: Scaffold and draft a new blog post under note/_posts or testbed/_posts following this repo's frontmatter, body-style, image, and follow-up conventions. Use when the user asks to write a post, draft a post, or expand a topic into a post.
-argument-hint: "[topic] [--language=en|kr] [--emoji=<file>] [--sources=<urls,paths>] [--category=note|testbed] [--slug=<slug>] [--at=<venue>]"
+argument-hint: "[topic] [--language=en|kr] [--emoji=<file>] [--sources=<urls,paths>] [--category=note|testbed] [--slug=<slug>] [--at=<venue>] [--thumbnail=<path>]"
 user-invocable: true
 allowed-tools: "Read Write Edit Bash Glob Grep WebFetch"
 ---
@@ -22,6 +22,7 @@ Parse the slash-command `ARGUMENTS:` line for the following flags. All optional.
 | `--category` | `note` / `testbed` | _(ask)_ | Skip if not provided — always confirm with `AskUserQuestion`. |
 | `--slug` | kebab-case slug | _(derive + confirm)_ | Filename slug without date prefix or extension. |
 | `--at` | venue / lab / event string (testbed only) | _(none)_ | **Do not pass an empty string.** Liquid treats `""` as truthy and renders a dangling `＠` marker in the testbed index. Omit the flag if there is no venue. Known special-cased values with link templates: `Visual Media Lab`, `Spacewalk`. |
+| `--thumbnail` | thumbnail path, e.g. `/img/<slug>/<slug>-thumbnail.png` (testbed only) | _(none)_ | **Pass only after the file actually exists.** `_includes/testbed.html` renders `<img src="…">` whenever the field is set, so a non-existent path becomes a broken image card on the testbed index. Omit the flag at scaffold time, generate the PNG in Step 8, and either rerun the scaffolder or add the line manually. |
 
 A free-text topic (anything in `ARGUMENTS:` outside the flags) is treated as the topic seed.
 
@@ -108,10 +109,13 @@ python3 "$SKILL_DIR/scripts/new_post.py" \
   --style "${STYLE}" \
   ${EMOJI:+--emoji "$EMOJI"} \
   ${LANGUAGE:+--language "$LANGUAGE"} \
-  ${AT:+--at "$AT"}
+  ${AT:+--at "$AT"} \
+  ${THUMBNAIL:+--thumbnail "$THUMBNAIL"}
 ```
 
-`--at` only applies to `--category=testbed` and **only** when there is a real venue. If the user did not pass `--at`, do not synthesise an empty value — the script omits the field entirely, which is the only safe behaviour given Liquid's truthiness rules.
+`--at` and `--thumbnail` only apply to `--category=testbed` and **only** when the value is real. If the user did not provide one, do not synthesise an empty string — the script omits the field entirely, which is the only safe behaviour given Liquid's truthiness rules. For `--thumbnail`, do not pass a path that does not yet exist on disk: the testbed index template renders an `<img>` tag whenever the field is set, so a non-existent path becomes a broken image card.
+
+Thumbnail follow-up: after the body is written and you produce the post's hero diagram in Step 8, also generate a card-sized thumbnail (square or 16:9) and save it to `img/<slug>/<slug>-thumbnail.png`. Then either re-run the scaffolder with `--thumbnail`, or insert the line `thumbnail: /img/<slug>/<slug>-thumbnail.png` into the frontmatter manually.
 
 The script writes `<category>/_posts/<date>-<slug>.html` and prints the path. It also creates `img/<slug>/` ahead of any diagram work.
 
@@ -120,7 +124,7 @@ Frontmatter rules:
 - `layout: post` — always.
 - `emoji:` — only if `--emoji` was provided.
 - `related: []` — empty list. **Do not populate.** Reserved for `/add-related`.
-- `testbed` adds: `hashtag`, `comment: true`, `splitter: 2`, `featured: false`, `inprogress: false`, `thumbnail: /img/<slug>/<slug>-thumbnail.png`. The `at:` line is **only** added when a real venue is provided via `--at`; an empty `at: ""` would render a dangling `＠` marker because Liquid treats `""` as truthy.
+- `testbed` adds: `hashtag`, `comment: true`, `splitter: 2`, `featured: false`, `inprogress: false`. The `at:` and `thumbnail:` lines are **only** added when real values are provided via `--at` and `--thumbnail`. Liquid treats both fields with truthy empty-string semantics in `_includes/testbed.html` and `_includes/meta.html`, so an empty `at: ""` would render a dangling `＠` marker and an empty (or non-existent) `thumbnail:` would render a broken `<img>` on the testbed index. The conventional thumbnail path is `/img/<slug>/<slug>-thumbnail.png`; pass it via `--thumbnail` only after the PNG actually exists.
 
 Full templates: `references/frontmatter.md`.
 

--- a/.agents/shared/skills/write-post/SKILL.md
+++ b/.agents/shared/skills/write-post/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: write-post
+description: Scaffold and draft a new blog post under note/_posts or testbed/_posts following this repo's frontmatter, body-style, image, and follow-up conventions. Use when the user asks to write a post, draft a post, or expand a topic into a post.
+argument-hint: "[topic] [--language=en|kr] [--emoji=<file>] [--sources=<urls,paths>] [--category=note|testbed] [--slug=<slug>]"
+user-invocable: true
+allowed-tools: "Read Write Edit Bash Glob Grep WebFetch"
+---
+
+# Write Post
+
+Draft a new blog post for `PARKCHEOLHEE-lab.github.io` end-to-end: confirm category and slug, scaffold the file, ingest sources, write the body in the correct style, generate diagrams when needed, verify the Jekyll build, and hand off to `/add-related`.
+
+## Arguments
+
+Parse the slash-command `ARGUMENTS:` line for the following flags. All optional.
+
+| Flag | Values | Default | Meaning |
+|---|---|---|---|
+| `--language` | `en` / `kr` | `en` | Body language. `en` = English, `kr` = Korean. |
+| `--emoji` | filename under `emoji/` (e.g. `brain.png`) or full path (e.g. `/emoji/brain.png`) | _(none)_ | Sets the `emoji:` frontmatter field. If omitted, the field is **not** generated. |
+| `--sources` | comma-separated list of URLs and/or local file paths | _(none)_ | Reference material. URLs are fetched via `WebFetch`; local paths are read with `Read`. |
+| `--category` | `note` / `testbed` | _(ask)_ | Skip if not provided — always confirm with `AskUserQuestion`. |
+| `--slug` | kebab-case slug | _(derive + confirm)_ | Filename slug without date prefix or extension. |
+
+A free-text topic (anything in `ARGUMENTS:` outside the flags) is treated as the topic seed.
+
+## Hard rules (do not violate)
+
+1. **Do not infer or write `related:` slugs.** The `related:` field is delegated to the `/add-related` skill. Leave it as an empty list (`related: []`) or omit the field entirely. After the post is written, instruct the user to run `/add-related --post-name=<slug>`.
+2. **Do not write SVG by hand.** All diagrams must be produced by validated math libraries: `matplotlib` for 2D, `three.js` + headless Chromium for 3D, `numpy` for numerical work. Hand-coded SVG paths are forbidden because they tend to be geometrically wrong.
+3. **`<figure>` tags must not sit inside `<li>` tags.** Place figures as siblings of the surrounding `<ul>`/`<ol>`, never as children of a list item. Compare to `note/_posts/2023-08-23-normalization-layers.html` for the canonical pattern.
+4. **No matplotlib spines on diagrams.** Always call `for s in ax.spines.values(): s.set_visible(False)` before saving — the user has explicitly rejected bordered figures.
+5. **Block math (`\[ ... \]`) must be wrapped in `<div class="latex-container">...</div>`.** Inline math (`\( ... \)`) does not need a wrapper. Reference: `note/_posts/2024-04-18-mathematics-for-machine-learning.html`.
+6. **Image paths follow `img/<slug>/<slug>-N.{png,jpg}`.** Single-image posts may use `img/<slug>/<slug>.png`. Always create the `img/<slug>/` directory before writing files.
+7. **Do not edit the generated `_site/` directory.** Source files only — Jekyll regenerates `_site/` on build.
+
+## Workflow
+
+### Step 1 — Resolve repo paths
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SKILL_DIR="${CLAUDE_SKILL_DIR:-$REPO_ROOT/.agents/shared/skills/write-post}"
+cd "$REPO_ROOT"
+```
+
+### Step 2 — Ingest sources (if `--sources` provided)
+
+For each entry in `--sources`:
+- Starts with `http://` or `https://` → `WebFetch` the URL with a prompt asking for the load-bearing facts, code snippets, and quotable lines.
+- Otherwise → treat as a local path and use `Read`.
+
+Keep the digested material in working memory. Do **not** quote sources verbatim in the body — the user prefers paraphrased explanations with sources cited at the end.
+
+### Step 3 — Confirm category
+
+Always run `AskUserQuestion`:
+
+- **note** — single concept, observation, short essay, or focused technical note. Examples: `window-crossing-selection`, `ego`, `limits-of-language`, `regression-model`.
+- **testbed** — long-form experiment / project writeup with profiling, multiple sections, and paper citations. Examples: `image-to-3d-scene`, `latent-shapes`, `office-layout-generation-agents`.
+
+Do not auto-decide. The user has answered "always ask" for this checkpoint.
+
+### Step 4 — Derive and confirm the slug
+
+Generate a kebab-case slug from the topic. Lowercase, ASCII, hyphen-separated, no stopwords like "the"/"a" unless meaningful. Confirm with `AskUserQuestion` before proceeding.
+
+The filename is `YYYY-MM-DD-<slug>.html` where the date is today (or whatever the user asks for). Run:
+
+```bash
+DATE="$(date +%F)"
+FILE="$REPO_ROOT/<note|testbed>/_posts/${DATE}-${SLUG}.html"
+```
+
+Abort if `$FILE` already exists — ask the user how to proceed.
+
+### Step 5 — Pick a body style
+
+Pick from three templates (full HTML wrappers in `references/body-styles.md`):
+
+| Style | When to pick | Wrapper |
+|---|---|---|
+| **outline** | Technical notes that explain structure or mechanism | nested `<ul><li>...</li><ul><li>...</li>...</ul></ul>` |
+| **prose** | Short essay, observation, prose-style technical intuition | `<div style="text-align: justify;">...<br><br>...</div>` |
+| **keyword** | Korean thought-jump posts (one short line per keyword/phrase) | `<div style="text-align: justify;">line<br>line<br>...</div>` |
+
+Inference cues:
+- `--language=kr` + topic is reflective/philosophical → likely **keyword** or **prose**
+- `--language=en` + topic involves code, math, or system mechanics → likely **outline**
+- `--category=testbed` → use **outline** with top-level `<h3>` section headings wrapped in `<div class="article">` blocks instead of nested `<ul>` (see `testbed/_posts/2026-02-03-image-to-3d-scene.html`)
+
+Confirm the chosen style with `AskUserQuestion` before writing.
+
+### Step 6 — Scaffold the file
+
+Use `scripts/new_post.py` to create the file with the frontmatter pre-filled and body wrapper ready:
+
+```bash
+python3 "$SKILL_DIR/scripts/new_post.py" \
+  --category "${CATEGORY}" \
+  --slug "${SLUG}" \
+  --title "${TITLE}" \
+  --style "${STYLE}" \
+  ${EMOJI:+--emoji "$EMOJI"} \
+  ${LANGUAGE:+--language "$LANGUAGE"}
+```
+
+The script writes `<category>/_posts/<date>-<slug>.html` and prints the path. It also creates `img/<slug>/` ahead of any diagram work.
+
+Frontmatter rules:
+- `title:` — quoted. `--language=kr` → Korean title; `--language=en` → English title.
+- `layout: post` — always.
+- `emoji:` — only if `--emoji` was provided.
+- `related: []` — empty list. **Do not populate.** Reserved for `/add-related`.
+- `testbed` adds: `hashtag`, `comment: true`, `splitter: 2`, `featured: false`, `inprogress: false`, `at: ""`, `thumbnail: /img/<slug>/<slug>-thumbnail.png`.
+
+Full templates: `references/frontmatter.md`.
+
+### Step 7 — Write the body in one shot
+
+Using the digested sources and the chosen style, write the **entire** body in one pass. Do not propose multiple candidates upfront — the user has chosen "write the full draft, then iterate on revisions."
+
+Style-specific guidance: `references/body-styles.md`.
+
+Tone:
+- **English (`en`)**: plain, direct, no first-person, sentence-case headings, prefer the active voice.
+- **Korean (`kr`)**: keep one register per post (do not mix `~다` and `~합니다`). Short sentences. `<br>`-separated thought-jumps for the keyword style.
+
+Sources are paraphrased into the body. End the post with a `Sources:` section if external references were used:
+
+```html
+<br><br>
+Sources:
+<ul>
+    <li><a href="https://...">Title</a></li>
+</ul>
+```
+
+For posts that cite a single LinkedIn / Tweet / external author, use the inline pattern instead:
+
+```html
+<br><br>
+Author Name's <a href="https://...">LinkedIn Post</a>
+```
+
+End every post with `<br><br>` (two trailing breaks).
+
+### Step 8 — Generate diagrams (only if needed)
+
+If the post benefits from a figure, generate it. Prefer:
+- **2D, geometry / math / data** → `matplotlib` (turn off all spines, no titles unless load-bearing, color-code consistently)
+- **3D, geometry / projection / cameras** → `three.js` rendered through headless Chromium (canonical pattern: see `references/images.md`)
+- **Networks / DAGs** → `matplotlib` + `networkx` or `graphviz`
+
+Save to `img/<slug>/<slug>-N.png` (N=0,1,2,…). Embed with:
+
+```html
+<figure>
+    <img src="/img/<slug>/<slug>-0.png" width="100%" onerror=handle_image_error(this)>
+    <figcaption>Optional caption</figcaption>
+</figure>
+```
+
+Never put `<figure>` inside `<li>`. Never hand-write SVG.
+
+If the math says a diagram should compare against a canonical reference (e.g., perspective projection vs Scratchapixel, line–line intersection vs Wikipedia), the user typically asks for that comparison after the first diagram. Be ready to fetch canonical references and verify visually.
+
+### Step 9 — Verify the build
+
+```bash
+bundle exec jekyll build 2>&1 | tail -30
+```
+
+If Jekyll fails, fix the source. If it succeeds and the user has the dev server running, suggest visiting `http://127.0.0.1:4000/<slug>/`.
+
+### Step 10 — Hand off to `/add-related`
+
+After the body is written and the build is green, tell the user:
+
+```
+Post written: <category>/_posts/<date>-<slug>.html
+Run `/add-related --post-name=<slug>` to populate the related: field.
+build-latentspace will run automatically when this post is merged to main.
+```
+
+Do **not** run `/add-related` automatically — the user invokes it explicitly.
+
+## What this skill does NOT do
+
+- Does not populate the `related:` frontmatter field. That is `/add-related`'s job.
+- Does not run `build-latentspace`. It triggers automatically on merge.
+- Does not create the PR. The user creates the PR when they are satisfied.
+- Does not commit. The user commits when ready.
+- Does not modify existing posts (other than adding figures requested via follow-up). For diagram or content updates to an existing post, treat it as a separate request.
+
+## References
+
+- `references/frontmatter.md` — full frontmatter templates per category.
+- `references/body-styles.md` — outline / prose / keyword wrappers and code/math conventions.
+- `references/images.md` — diagram production with matplotlib / three.js + headless Chromium.
+- `references/examples.md` — slug → category, style, language mapping for representative posts.

--- a/.agents/shared/skills/write-post/SKILL.md
+++ b/.agents/shared/skills/write-post/SKILL.md
@@ -76,18 +76,22 @@ Abort if `$FILE` already exists — ask the user how to proceed.
 
 ### Step 5 — Pick a body style
 
-Pick from three templates (full HTML wrappers in `references/body-styles.md`):
+Pick from four templates (full HTML wrappers in `references/body-styles.md`). The `--style` value passed to `scripts/new_post.py` must be one of these exact tokens.
 
 | Style | When to pick | Wrapper |
 |---|---|---|
-| **outline** | Technical notes that explain structure or mechanism | nested `<ul><li>...</li><ul><li>...</li>...</ul></ul>` |
-| **prose** | Short essay, observation, prose-style technical intuition | `<div style="text-align: justify;">...<br><br>...</div>` |
-| **keyword** | Korean thought-jump posts (one short line per keyword/phrase) | `<div style="text-align: justify;">line<br>line<br>...</div>` |
+| `outline` | `note` posts that explain structure or mechanism | nested `<ul><li>...</li><ul><li>...</li>...</ul></ul>` |
+| `prose` | `note` short essay, observation, prose-style technical intuition | `<div style="text-align: justify;">...<br><br>...</div>` |
+| `keyword` | `note` Korean thought-jump posts (one short line per keyword/phrase) | `<div style="text-align: justify;">line<br>line<br>...</div>` |
+| `testbed-longform` | All `testbed` posts — long-form experiment / project writeups | `<div id="toc"></div>` + repeated `<h3>Title</h3><div class="article">…</div><br><br>` blocks |
 
-Inference cues:
-- `--language=kr` + topic is reflective/philosophical → likely **keyword** or **prose**
-- `--language=en` + topic involves code, math, or system mechanics → likely **outline**
-- `--category=testbed` → use **outline** with top-level `<h3>` section headings wrapped in `<div class="article">` blocks instead of nested `<ul>` (see `testbed/_posts/2026-02-03-image-to-3d-scene.html`)
+Category → style hard rules:
+- `--category=testbed` → **must** use `testbed-longform`. The other three styles are `note` wrappers and produce the wrong HTML structure for testbed posts. See `testbed/_posts/2026-02-03-image-to-3d-scene.html` for the canonical shape.
+- `--category=note` → pick one of `outline`, `prose`, `keyword`. `testbed-longform` is forbidden inside `note/_posts`.
+
+Inference cues for `note`:
+- `--language=kr` + topic is reflective/philosophical → likely `keyword` or `prose`
+- `--language=en` + topic involves code, math, or system mechanics → likely `outline`
 
 Confirm the chosen style with `AskUserQuestion` before writing.
 
@@ -167,11 +171,16 @@ If the math says a diagram should compare against a canonical reference (e.g., p
 
 ### Step 9 — Verify the build
 
+`bundle exec jekyll build | tail -30` would mask Jekyll failures because the pipeline exit status is `tail`'s, not Jekyll's. Capture the log to a file and check Jekyll's own exit status:
+
 ```bash
-bundle exec jekyll build 2>&1 | tail -30
+bundle exec jekyll build >/tmp/jekyll-build.log 2>&1
+status=$?
+tail -30 /tmp/jekyll-build.log
+[ "$status" = "0" ] || { echo "BUILD FAILED (exit $status)"; exit "$status"; }
 ```
 
-If Jekyll fails, fix the source. If it succeeds and the user has the dev server running, suggest visiting `http://127.0.0.1:4000/<slug>/`.
+If Jekyll fails, read the captured log, fix the source, and re-run. If it succeeds and the user has the dev server running, suggest visiting `http://127.0.0.1:4000/<slug>/`.
 
 ### Step 10 — Hand off to `/add-related`
 

--- a/.agents/shared/skills/write-post/SKILL.md
+++ b/.agents/shared/skills/write-post/SKILL.md
@@ -120,7 +120,7 @@ Frontmatter rules:
 - `layout: post` — always.
 - `emoji:` — only if `--emoji` was provided.
 - `related: []` — empty list. **Do not populate.** Reserved for `/add-related`.
-- `testbed` adds: `hashtag`, `comment: true`, `splitter: 2`, `featured: false`, `inprogress: false`, `at: ""`, `thumbnail: /img/<slug>/<slug>-thumbnail.png`.
+- `testbed` adds: `hashtag`, `comment: true`, `splitter: 2`, `featured: false`, `inprogress: false`, `thumbnail: /img/<slug>/<slug>-thumbnail.png`. The `at:` line is **only** added when a real venue is provided via `--at`; an empty `at: ""` would render a dangling `＠` marker because Liquid treats `""` as truthy.
 
 Full templates: `references/frontmatter.md`.
 

--- a/.agents/shared/skills/write-post/references/body-styles.md
+++ b/.agents/shared/skills/write-post/references/body-styles.md
@@ -1,0 +1,216 @@
+# Body Style Templates
+
+Three templates cover the patterns observed in this repo. Pick one before writing.
+
+## 1. Outline (technical notes)
+
+Used for posts that explain a structure, mechanism, or step-by-step thought. Section titles are siblings; details live in nested `<ul>`.
+
+```html
+<br>
+
+<ul>
+    <li>
+        Section Title 1
+    </li>
+        <ul>
+            <li>
+                Body sentence 1. <code>identifier</code> in inline code, <b>bold</b> for emphasis.
+            </li>
+            <li>
+                Body sentence 2. Code block:
+
+<pre><code class="typescript">
+    function example() {
+        return 42;
+    }
+</code></pre>
+
+                Continued explanation after the code.
+            </li>
+        </ul>
+    <figure>
+        <img src="/img/&lt;slug&gt;/&lt;slug&gt;-0.png" width="100%" onerror=handle_image_error(this)>
+    </figure>
+    <br>
+    <li>
+        Section Title 2
+    </li>
+        <ul>
+            <li>
+                Math inline: \(\beta_0 + \beta_1 X\). Block math:
+                <div class="latex-container">
+                \[
+                    Y_i = \beta_0 + \beta_1 X_i + \epsilon_i, \quad \epsilon_i \sim N(0, \sigma^2)
+                \]
+                </div>
+            </li>
+        </ul>
+    <br>
+</ul>
+
+<br><br>
+```
+
+Rules:
+- Section titles `<li>` are direct children of the outer `<ul>`.
+- Detail bullets live in a nested `<ul>` immediately after each section title.
+- `<figure>` is a sibling of the inner `<ul>`, never a child of `<li>`.
+- Use `<br>` between sections, not extra `<li>` spacers.
+- Code blocks use `<pre><code class="LANG">…</code></pre>`. The `class` matches the language for syntax highlighting (`typescript`, `python`, `bash`, `cpp`, `text`).
+- Indentation inside `<pre>` uses 4 spaces.
+
+Reference posts:
+- `note/_posts/2026-04-25-window-crossing-selection.html`
+- `note/_posts/2026-04-09-triangle-menu-aim.html`
+- `note/_posts/2026-03-15-regression-model.html`
+
+## 2. Prose (short essay / observation)
+
+Used for short reflective posts and prose-style technical intuitions. Body sits inside one justified `<div>`.
+
+```html
+<br>
+
+<div style="text-align: justify;">
+    First paragraph. Plain prose, no headings, no bullet points.
+
+    <br><br>
+
+    Second paragraph. Use <code>code</code> and <b>bold</b> sparingly.
+
+    <figure>
+        <img src="/img/&lt;slug&gt;/&lt;slug&gt;-0.png" width="100%" onerror=handle_image_error(this)>
+        <figcaption class="nofig">
+            Optional caption
+        </figcaption>
+    </figure>
+
+    <br><br>
+
+    Third paragraph.
+
+</div>
+
+
+<br><br>
+```
+
+Rules:
+- Paragraphs are separated by `<br><br>`, not `<p>` tags.
+- Inline math with `\(...\)`, block math wrapped in `<div class="latex-container">`.
+- Single-author voice; no first-person plural unless quoting a paper.
+- Korean prose: pick `~다` or `~합니다` and stick with it. Do not mix.
+
+Reference posts:
+- `note/_posts/2026-02-13-intuitions-about-diffusion-models.html`
+- `note/_posts/2026-02-05-ego.html` (Korean)
+- `note/_posts/2026-03-08-spurting.html` (Korean)
+
+## 3. Keyword (Korean thought-jump)
+
+Used for Korean posts that expand a concept by line-jumping through associations. Each line is short and self-contained; `<br>` separates them.
+
+```html
+<br>
+
+<div style="text-align: justify;">
+
+    키워드 1
+    <br>
+    키워드 2
+    <br>
+    한 줄짜리 사고 점프
+    <br>
+    또 다른 점프
+
+</div>
+
+<br><br>
+```
+
+Rules:
+- One short line per `<br>`.
+- No periods at the end of lines (matches `limits-of-language` style).
+- Lines should be punchy and self-contained — each readable as a standalone aphorism.
+- The user has historically rejected the first attempt and asked for many candidates. If `--language=kr` and the chosen style is `keyword`, the assistant should be ready to fall back to "propose 30–50 candidate lines, let the user pick" if the first draft is rejected.
+
+Reference posts:
+- `note/_posts/2026-04-17-limits-of-language.html`
+- `note/_posts/_words.html` (disabled but stylistically the same)
+
+## Testbed long-form
+
+Long technical writeups in `testbed/_posts/` use a different wrapper: top-level `<h3>` headings, each section in its own `<div class="article">`.
+
+```html
+<div id="toc"></div>
+
+<h3>Introduction</h3>
+<div class="article">
+    Lead paragraph framing the project, funding, and goal.
+</div><br><br>
+
+<h3>Section Title</h3>
+<div class="article">
+    Body, code, math, figures.
+
+    <figure style="display: flex;">
+        <img src="/img/&lt;slug&gt;/&lt;slug&gt;-0.png" width="45%" onerror=handle_image_error(this)>
+        <img src="/img/&lt;slug&gt;/&lt;slug&gt;-1.png" width="45%" onerror=handle_image_error(this)>
+    </figure>
+    <figcaption>Side-by-side caption</figcaption>
+
+<pre><code class="python">
+import torch
+</code></pre>
+
+</div><br><br>
+```
+
+Rules:
+- Begin with `<div id="toc"></div>` for the table-of-contents widget.
+- Each section: `<h3>Title</h3>` then `<div class="article">…</div><br><br>`.
+- Multi-image figures use `style="display: flex;"` with `width` per image.
+- Long quoted blocks from papers can be HTML-commented out (`<!-- … -->`) if the paraphrase replaces them — keep the original for reference but don't render.
+
+Reference post:
+- `testbed/_posts/2026-02-03-image-to-3d-scene.html`
+
+## Code blocks
+
+Always use `<pre><code class="LANG">…</code></pre>`. Common language tags in this repo:
+
+| Tag | Used for |
+|---|---|
+| `typescript` | Front-end / Three.js / web code |
+| `python` | ML, scripts, PyTorch |
+| `bash` | Shell snippets |
+| `cpp` | Performance-sensitive code |
+| `glsl` | Shader code |
+| `text` | Generic / log output |
+
+Indent code with 4 spaces. Keep snippets short — quote the load-bearing 5–20 lines, not entire files. If a snippet references a specific file, mention `<path>:<line>` in the surrounding prose (e.g. `threeView.ts:409`).
+
+## Math
+
+| Form | Markup |
+|---|---|
+| Inline | `\(\beta_0 + \beta_1 X\)` |
+| Block | `<div class="latex-container">\[ Y_i = \beta_0 + \beta_1 X_i + \epsilon_i \]</div>` |
+
+Multiple block-math expressions in one section each get their own `<div class="latex-container">`.
+
+## Closing
+
+Every post ends with `<br><br>` (two trailing breaks) before the closing of the file. If a `Sources:` or attribution section exists, it goes **before** the trailing `<br><br>`:
+
+```html
+<br><br>
+Sources:
+<ul>
+    <li><a href="https://...">Title</a></li>
+</ul>
+
+<br><br>
+```

--- a/.agents/shared/skills/write-post/references/examples.md
+++ b/.agents/shared/skills/write-post/references/examples.md
@@ -39,8 +39,10 @@ When unsure which category to pick, use these rules of thumb (then confirm with 
 1. **Output of a project / experiment with profiling, multiple sections, paper references** → testbed
 2. **Single concept / observation / mechanism explanation** → note
 3. **Short reflection or thought-jump in Korean** → note (prose or keyword)
-4. **Cheat sheet or reference list** → note (often gets `clip.png` or `pin.png` emoji)
+4. **Cheat sheet or reference list** → note (use `pin.png` emoji, or omit emoji to fall back to the "Note" label)
 5. **Book or quote-driven essay** → note with `books.png` emoji
+
+Only the seven emojis mapped in `build-latentspace`'s `EMOJI_TO_LABEL` (`brain`, `books`, `pin`, `eyes`, `wordballoon-with-dots`, `robot`, `storm`) produce a non-default latent-space label. Other emoji files exist under `emoji/` but are silently labeled "Note" — see `references/frontmatter.md` for the canonical table.
 
 When unsure which body style to pick:
 

--- a/.agents/shared/skills/write-post/references/examples.md
+++ b/.agents/shared/skills/write-post/references/examples.md
@@ -1,0 +1,58 @@
+# Example Mapping
+
+Representative existing posts mapped to category, language, and style. Use these as reference when classifying a new post.
+
+## note/_posts/
+
+| Slug | Language | Style | Emoji | Why |
+|---|---|---|---|---|
+| `2026-04-25-window-crossing-selection` | en | outline | _(none)_ | Mechanism explanation with code, math, and 4 diagrams |
+| `2026-04-09-triangle-menu-aim` | en | outline | _(none)_ | UX pattern explained with code and one diagram |
+| `2026-03-15-regression-model` | en | outline | _(none)_ | Statistical concept with math and an interactive canvas |
+| `2026-03-12-wasm` | en | outline | _(none)_ | Tooling note |
+| `2026-02-13-intuitions-about-diffusion-models` | en | prose | _(none)_ | Math-prose intuition with one figure |
+| `2026-02-05-ego` | kr | prose | `eyes.png` | Reflective essay quoting a LinkedIn post |
+| `2026-04-17-limits-of-language` | kr | keyword | `wordballoon-with-dots.png` | Thought-jump on language and AI |
+| `2026-03-08-spurting` | kr | prose | `wordballoon-with-dots.png` | Short reflection with one figure |
+| `2026-01-03-standardization` | en | outline | _(none)_ | Stat preprocessing concept |
+| `2025-09-17-pca` | en | outline | _(none)_ | ML concept deep-dive |
+| `2025-08-04-layout-vlm` | en | outline | _(none)_ | Long technical note (~26KB), still note-shaped |
+| `2025-07-29-no-longer-human` | kr | prose | `books.png` | Book quote / reflection |
+| `2025-06-16-capability-overhang` | en | prose | `eyes.png` | Industry observation |
+| `2025-06-09-truth` | en | prose | `wordballoon-with-dots.png` | Philosophy / reflection |
+
+## testbed/_posts/
+
+| Slug | Language | Style | At | Notes |
+|---|---|---|---|---|
+| `2026-02-03-image-to-3d-scene` | en | testbed long-form | Visual Media Lab | Pipeline writeup with paper citations |
+| `2025-08-11-latent-shapes` | en | testbed long-form | _(varies)_ | Generative shape experiment |
+| `2025-07-30-office-layout-generation-agents` | en | testbed long-form | _(varies)_ | Multi-agent + GA optimization |
+| `2025-04-02-voxels-to-graph` | en | testbed long-form | _(varies)_ | Voxel → graph conversion |
+| `2024-12-02-landbook-diffusion-pipeline` | en | testbed long-form | Landbook | Diffusion pipeline writeup |
+| `2024-06-07-polygon-segmentation` | en | testbed long-form | _(varies)_ | Algorithmic deep-dive |
+
+## Decision rules
+
+When unsure which category to pick, use these rules of thumb (then confirm with `AskUserQuestion`):
+
+1. **Output of a project / experiment with profiling, multiple sections, paper references** → testbed
+2. **Single concept / observation / mechanism explanation** → note
+3. **Short reflection or thought-jump in Korean** → note (prose or keyword)
+4. **Cheat sheet or reference list** → note (often gets `clip.png` or `pin.png` emoji)
+5. **Book or quote-driven essay** → note with `books.png` emoji
+
+When unsure which body style to pick:
+
+1. The topic explains a step-by-step mechanism with code and math → outline
+2. The topic is a short observation / intuition / quote-and-react → prose
+3. Korean, short punchy lines, philosophical → keyword
+
+## Past user feedback to watch for
+
+- "다 구리다" / "더 날카롭게" → prose or keyword first attempt rejected, fall back to "propose 30–50 candidates, let user pick"
+- "figure는 li 안에 넣지마" → fix figure placement
+- "테두리 없어도 됨" → matplotlib spine removal
+- "더 좋은방법 없음? threejs" → swap mock matplotlib 3D for real Three.js render
+- "내용 자체를 기준으로" / "이상한소리 말고" → cut the meta-commentary, give substance
+- "다이어그램이 적절한지 인터넷과 비교" → fetch canonical refs and compare side-by-side

--- a/.agents/shared/skills/write-post/references/frontmatter.md
+++ b/.agents/shared/skills/write-post/references/frontmatter.md
@@ -20,24 +20,19 @@ related: []
 |---|---|---|
 | `emoji` | Only for essay / observation / reflective posts | `emoji: /emoji/eyes.png` |
 
-The `emoji` field maps to a label on the latent-space visualization. Available files (under `emoji/`):
+The `emoji` field maps to a label on the latent-space visualization. **Only the seven files in the table below have label mappings** — the latent-space mapper (`.agents/shared/skills/build-latentspace/scripts/build_post_map.py`'s `EMOJI_TO_LABEL`) recognises exactly these. Setting any other filename (even ones present under `emoji/` like `bulb.png`, `pencil.png`, `dna.png`, `clip.png`, `fire.png`, `wordballoon.png`) silently falls back to the "Note" label, which is almost never what you want.
 
-| File | Used for |
-|---|---|
-| `brain.png` | ML / theory deep-dive |
-| `books.png` | Book quotes, reading reflections |
-| `pin.png` | Reading list, bookmarked references |
-| `eyes.png` | Observation / commentary on industry / ego |
-| `wordballoon-with-dots.png` | Quiet thought, philosophical posts |
-| `robot.png` | AI behavior, agents, automation |
-| `storm.png` | Strong-opinion essays |
-| `bulb.png` | Insight / quick aha posts |
-| `pencil.png` | Writing / drafting / process posts |
-| `dna.png` | Identity / formation / origin posts |
-| `clip.png` | Cheat sheets / clipped-fact posts |
-| `fire.png` | Urgency / breakthrough |
+| File | Label | Used for |
+|---|---|---|
+| `brain.png` | Brain | ML / theory deep-dive |
+| `books.png` | Books | Book quotes, reading reflections |
+| `pin.png` | Pin | Reading list, bookmarked references |
+| `eyes.png` | Eyes | Observation / commentary on industry / ego |
+| `wordballoon-with-dots.png` | Wordballoon | Quiet thought, philosophical posts |
+| `robot.png` | Robot | AI behavior, agents, automation |
+| `storm.png` | Storm | Strong-opinion essays |
 
-**Do not invent new emoji names.** If none fits and the topic is reflective, omit the field — it falls back to the "Note" label.
+**Do not invent new emoji names.** If none fits, omit the field — it falls back to the "Note" label deliberately. To add a new emoji, register it in `EMOJI_TO_LABEL` first (and update this table).
 
 ### Examples
 
@@ -72,7 +67,7 @@ related: []
 
 ## `testbed/_posts/` — long-form experiment / project writeup
 
-### Full template
+### Full template (no venue)
 
 ```yaml
 ---
@@ -83,10 +78,17 @@ comment: true
 splitter: 2
 featured: false
 inprogress: false
-at: ""
 thumbnail: /img/<slug>/<slug>-thumbnail.png
 related: []
 ---
+```
+
+### With a venue
+
+If the project was done at a specific lab or event, add an `at:` line. **Do not use an empty string** — Liquid treats `""` as truthy, so `_includes/testbed.html` and `_includes/meta.html` would render a dangling `＠` marker. Either include a real venue or omit the field entirely.
+
+```yaml
+at: "Visual Media Lab"
 ```
 
 | Field | Notes |
@@ -95,8 +97,8 @@ related: []
 | `comment` | Almost always `true`. |
 | `splitter` | Almost always `2`. Controls layout column split. |
 | `featured` | `true` puts the post in the featured slot on the landing page. Default `false`. |
-| `inprogress` | `true` while still drafting. Set `false` when the post is shippable. |
-| `at` | Lab / event / venue name (e.g. `Visual Media Lab`, `KOCCA`). Empty string if none. |
+| `inprogress` | `true` while still drafting. Set `false` when the post is shippable. The scaffolder writes `false` so the post is shippable as soon as the body is ready; flip to `true` if you want it tagged as a draft. |
+| `at` | Lab / event / venue name (e.g. `Visual Media Lab`, `Spacewalk`). **Omit the line entirely if there is no venue.** Two `at:` values have dedicated link templates in `_includes/meta.html` (`Spacewalk`, `Visual Media Lab`); other values render as plain text. |
 | `thumbnail` | Path to a card-sized thumbnail. Generate after the body is written. |
 
 ### Example

--- a/.agents/shared/skills/write-post/references/frontmatter.md
+++ b/.agents/shared/skills/write-post/references/frontmatter.md
@@ -67,7 +67,7 @@ related: []
 
 ## `testbed/_posts/` — long-form experiment / project writeup
 
-### Full template (no venue)
+### Scaffold-time template (no venue, no thumbnail yet)
 
 ```yaml
 ---
@@ -78,10 +78,11 @@ comment: true
 splitter: 2
 featured: false
 inprogress: false
-thumbnail: /img/<slug>/<slug>-thumbnail.png
 related: []
 ---
 ```
+
+The scaffolder writes this minimal shape on purpose — neither `at:` nor `thumbnail:` is included. Both fields are rendered through Liquid `{% if … %}` blocks that treat any string (including `""`) as truthy, so emitting them with placeholder values causes broken markup on the testbed index.
 
 ### With a venue
 
@@ -89,6 +90,14 @@ If the project was done at a specific lab or event, add an `at:` line. **Do not 
 
 ```yaml
 at: "Visual Media Lab"
+```
+
+### With a thumbnail
+
+Add `thumbnail:` only after the PNG exists on disk. `_includes/testbed.html:57` renders `<img src="{{ post.thumbnail }}">` whenever the field is truthy, so a non-existent path becomes a broken image card on the testbed index. Convention: `/img/<slug>/<slug>-thumbnail.png`.
+
+```yaml
+thumbnail: /img/<slug>/<slug>-thumbnail.png
 ```
 
 | Field | Notes |
@@ -99,7 +108,7 @@ at: "Visual Media Lab"
 | `featured` | `true` puts the post in the featured slot on the landing page. Default `false`. |
 | `inprogress` | `true` while still drafting. Set `false` when the post is shippable. The scaffolder writes `false` so the post is shippable as soon as the body is ready; flip to `true` if you want it tagged as a draft. |
 | `at` | Lab / event / venue name (e.g. `Visual Media Lab`, `Spacewalk`). **Omit the line entirely if there is no venue.** Two `at:` values have dedicated link templates in `_includes/meta.html` (`Spacewalk`, `Visual Media Lab`); other values render as plain text. |
-| `thumbnail` | Path to a card-sized thumbnail. Generate after the body is written. |
+| `thumbnail` | Path to a card-sized thumbnail PNG that already exists on disk. **Omit the line entirely until the file is generated**, otherwise `_includes/testbed.html:57` renders a broken `<img>`. Generate the thumbnail after the body is written and add this line then (or rerun the scaffolder with `--thumbnail`). |
 
 ### Example
 

--- a/.agents/shared/skills/write-post/references/frontmatter.md
+++ b/.agents/shared/skills/write-post/references/frontmatter.md
@@ -1,0 +1,130 @@
+# Frontmatter Templates
+
+This repo's posts use YAML frontmatter at the top of every `.html` file, between `---` delimiters. The fields differ by category.
+
+## `note/_posts/` — short concept / essay / focused technical note
+
+### Minimum (always required)
+
+```yaml
+---
+title: "<Title>"
+layout: post
+related: []
+---
+```
+
+### Optional fields
+
+| Field | When | Example |
+|---|---|---|
+| `emoji` | Only for essay / observation / reflective posts | `emoji: /emoji/eyes.png` |
+
+The `emoji` field maps to a label on the latent-space visualization. Available files (under `emoji/`):
+
+| File | Used for |
+|---|---|
+| `brain.png` | ML / theory deep-dive |
+| `books.png` | Book quotes, reading reflections |
+| `pin.png` | Reading list, bookmarked references |
+| `eyes.png` | Observation / commentary on industry / ego |
+| `wordballoon-with-dots.png` | Quiet thought, philosophical posts |
+| `robot.png` | AI behavior, agents, automation |
+| `storm.png` | Strong-opinion essays |
+| `bulb.png` | Insight / quick aha posts |
+| `pencil.png` | Writing / drafting / process posts |
+| `dna.png` | Identity / formation / origin posts |
+| `clip.png` | Cheat sheets / clipped-fact posts |
+| `fire.png` | Urgency / breakthrough |
+
+**Do not invent new emoji names.** If none fits and the topic is reflective, omit the field — it falls back to the "Note" label.
+
+### Examples
+
+`note/_posts/2026-04-25-window-crossing-selection.html` — technical note, no emoji:
+```yaml
+---
+title: "Window/Crossing Selection"
+layout: post
+related: []
+---
+```
+
+`note/_posts/2026-02-05-ego.html` — reflective essay, emoji set:
+```yaml
+---
+title: "ego"
+layout: post
+emoji: /emoji/eyes.png
+related: []
+---
+```
+
+`note/_posts/2026-04-17-limits-of-language.html` — Korean keyword post:
+```yaml
+---
+title: "언어의 한계"
+layout: post
+emoji: /emoji/wordballoon-with-dots.png
+related: []
+---
+```
+
+## `testbed/_posts/` — long-form experiment / project writeup
+
+### Full template
+
+```yaml
+---
+title: "<Title>"
+layout: post
+hashtag: "#tag1 #tag2 #tag3"
+comment: true
+splitter: 2
+featured: false
+inprogress: false
+at: ""
+thumbnail: /img/<slug>/<slug>-thumbnail.png
+related: []
+---
+```
+
+| Field | Notes |
+|---|---|
+| `hashtag` | Three to five short tags, prefixed with `#`, space-separated, all wrapped in a single quoted string. |
+| `comment` | Almost always `true`. |
+| `splitter` | Almost always `2`. Controls layout column split. |
+| `featured` | `true` puts the post in the featured slot on the landing page. Default `false`. |
+| `inprogress` | `true` while still drafting. Set `false` when the post is shippable. |
+| `at` | Lab / event / venue name (e.g. `Visual Media Lab`, `KOCCA`). Empty string if none. |
+| `thumbnail` | Path to a card-sized thumbnail. Generate after the body is written. |
+
+### Example
+
+`testbed/_posts/2026-02-03-image-to-3d-scene.html`:
+```yaml
+---
+title: "Image to 3D Scene Pipeline"
+layout: post
+hashtag: "#sam #sam-3d-objects #generative-design"
+comment: true
+splitter: 2
+featured: false
+inprogress: false
+at: Visual Media Lab
+thumbnail: /img/image-to-3d-scene/image-to-3d-scene-thumbnail.png
+related: []
+---
+```
+
+## What never goes in frontmatter
+
+- `date:` — the date is in the filename. Do not duplicate.
+- `tags:` (Jekyll's default tags taxonomy) — this repo uses `hashtag` for testbed instead.
+- `categories:` — the category is implicit from `note/_posts/` vs `testbed/_posts/`.
+- `permalink:` — Jekyll derives it from the slug.
+- `author:` — single-author blog, configured at the site level.
+
+## `related: []` is the contract
+
+The skill **must** leave `related:` empty. The `/add-related` skill is the single source of truth for related-slug computation. Writing slugs into `related:` from `write-post` violates the contract and the user has explicitly instructed against it.

--- a/.agents/shared/skills/write-post/references/images.md
+++ b/.agents/shared/skills/write-post/references/images.md
@@ -1,0 +1,125 @@
+# Images and Diagrams
+
+Images for a post live in `img/<slug>/`. Naming: `<slug>-0.png`, `<slug>-1.png`, … (zero-indexed). Single-image posts may use `<slug>.png`. Thumbnails (testbed only): `<slug>-thumbnail.png`.
+
+## Hard rules
+
+1. **Never write SVG by hand.** Hand-coded SVG paths are geometrically wrong almost every time. Use a math library.
+2. **No matplotlib spines.** Always remove all four spines before saving:
+   ```python
+   for s in ax.spines.values():
+       s.set_visible(False)
+   ```
+3. **`<figure>` is a sibling of the surrounding list, never a child of `<li>`.**
+4. **Default width is 100%.** Use `70%` for narrow figures, `45%` × 2 for side-by-side.
+
+## Library selection
+
+| Need | Library | Notes |
+|---|---|---|
+| 2D geometry, math curves, scatter, lines | `matplotlib` | Spines off, no axis ticks unless meaningful, color-code consistently |
+| Numerical work feeding into a plot | `numpy` | Compute first, plot once |
+| 3D scenes, cameras, projection, frustums | `three.js` + headless Chromium | Real WebGL render, screenshot to PNG |
+| Graphs, DAGs, trees | `matplotlib` + `networkx`, or `graphviz` | Use only if the topology actually carries the message |
+| Data plots, regressions, confusion matrices | `matplotlib` | Same spine/styling rules |
+
+## matplotlib pattern
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+
+fig, ax = plt.subplots(figsize=(8, 6), dpi=200)
+
+# ... plot here ...
+
+# remove all spines (user has rejected bordered figures)
+for s in ax.spines.values():
+    s.set_visible(False)
+ax.set_xticks([])
+ax.set_yticks([])
+ax.set_aspect("equal")
+
+fig.tight_layout()
+fig.savefig("img/<slug>/<slug>-0.png", bbox_inches="tight", pad_inches=0.05, transparent=False)
+```
+
+Color rules observed in this repo:
+- Two-element comparison → blue (`#3b82f6` / matplotlib `tab:blue`) and green (`#22c55e` / `tab:green`).
+- Window/crossing canonical: solid blue = window, dashed green = crossing.
+- Selection / overlay rectangles: dashed border, translucent fill (alpha 0.15–0.30).
+- Annotations / labels: short, no italic captions inside the figure (legend handles names).
+
+## three.js + headless Chromium pattern
+
+For 3D scenes, prefer real WebGL renders captured by Playwright / Puppeteer headless Chromium. matplotlib's `mpl_toolkits.mplot3d` produces flat-looking renders the user has rejected.
+
+Skeleton:
+
+1. Write `scripts/render_<slug>.html` containing a Three.js scene that:
+   - Sets up the camera, geometry, lights, and any helpers (`THREE.CameraHelper`, `THREE.GridHelper`).
+   - Renders to a canvas and exposes a global flag (e.g. `window.__rendered = true`) once render completes.
+   - Optionally projects 3D points back to 2D for HTML overlay labels (use `Vector3.project(camera)`).
+2. Run a headless Chromium screenshot:
+   ```bash
+   npx playwright install chromium  # one-time
+   node scripts/render_<slug>.js    # opens the HTML, waits for __rendered, screenshots canvas
+   ```
+3. Write the resulting PNG to `img/<slug>/<slug>-<N>.png`.
+
+Practical notes from past sessions:
+- Use software WebGL flags if the headless render comes out blank.
+- Build one canvas with two scissored viewports rather than two separate WebGL contexts (the second context often refuses to render in Chromium).
+- For comparison panels (e.g., "outside-observer view" vs "user view"), construct the second camera explicitly — do **not** call `camera.clone()` (matrix staleness).
+- Label points by projecting world coordinates back to canvas pixels and overlaying `<span>` elements with absolute positioning.
+
+## When to add a diagram
+
+Add a diagram when:
+- The post explains a geometric construction, projection, or hit-test.
+- The post derives a math formula and a figure makes the variables tangible.
+- The user asks for one (e.g., "이 포스트에 다이어그램 적재적소에 넣어줘").
+
+Skip a diagram when:
+- The post is a short essay or keyword-jump.
+- The math is one-liner and the equation reads itself.
+- The figure would be decorative.
+
+## Verification step (recommended)
+
+After producing a diagram, briefly compare it against canonical references:
+- 2D geometry → Wikipedia / sunshine2k / mathematicsart
+- 3D projection → Scratchapixel, Songho, jsantell
+- ML diagrams → original paper figures
+
+This is a habit the user has explicitly asked for — "다이어그램이 적절한지 너가만든것과 인터넷에 떠돌아다니는 것과 비교."
+
+If the canonical convention differs (e.g., color, label, axis orientation), match the canonical unless the post argues for a deliberate variation.
+
+## Embedding HTML
+
+Single image, full width:
+```html
+<figure>
+    <img src="/img/<slug>/<slug>-0.png" width="100%" onerror=handle_image_error(this)>
+</figure>
+```
+
+With caption:
+```html
+<figure>
+    <img src="/img/<slug>/<slug>-0.png" width="70%" onerror=handle_image_error(this)>
+    <figcaption>Caption text</figcaption>
+</figure>
+```
+
+Side-by-side (testbed style):
+```html
+<figure style="display: flex;">
+    <img src="/img/<slug>/<slug>-0.png" width="45%" onerror=handle_image_error(this)>
+    <img src="/img/<slug>/<slug>-1.png" width="45%" onerror=handle_image_error(this)>
+</figure>
+<figcaption>From the left, original · processed</figcaption>
+```
+
+`onerror=handle_image_error(this)` is the repo's standard fallback handler — always include it.

--- a/.agents/shared/skills/write-post/scripts/new_post.py
+++ b/.agents/shared/skills/write-post/scripts/new_post.py
@@ -69,7 +69,11 @@ def frontmatter_note(title: str, emoji: str | None) -> str:
 
 
 def frontmatter_testbed(
-    title: str, slug: str, emoji: str | None, at: str | None = None
+    title: str,
+    slug: str,
+    emoji: str | None,
+    at: str | None = None,
+    thumbnail: str | None = None,
 ) -> str:
     lines = [
         "---",
@@ -80,8 +84,9 @@ def frontmatter_testbed(
         "splitter: 2",
         "featured: false",
         "inprogress: false",
-        f"thumbnail: /img/{slug}/{slug}-thumbnail.png",
     ]
+    if thumbnail:
+        lines.append(f"thumbnail: {thumbnail}")
     if at:
         lines.append(f"at: {yaml_double_quote(at)}")
     if emoji:
@@ -162,6 +167,7 @@ def build_post(
     date: _dt.date,
     root: Path,
     at: str | None = None,
+    thumbnail: str | None = None,
 ) -> Path:
     if category not in VALID_CATEGORIES:
         raise ValueError(f"category must be one of {VALID_CATEGORIES}, got {category!r}")
@@ -189,7 +195,7 @@ def build_post(
     if category == "note":
         fm = frontmatter_note(title, emoji)
     else:
-        fm = frontmatter_testbed(title, slug, emoji, at=at)
+        fm = frontmatter_testbed(title, slug, emoji, at=at, thumbnail=thumbnail)
 
     body = BODY_BUILDERS[style]()
 
@@ -213,6 +219,11 @@ def main(argv: list[str] | None = None) -> int:
         "--at",
         default="",
         help="Testbed venue/lab/event (e.g. 'Visual Media Lab'). Omit for none — empty string would render a dangling marker because Liquid treats empty strings as truthy.",
+    )
+    parser.add_argument(
+        "--thumbnail",
+        default="",
+        help="Thumbnail path (testbed only, e.g. /img/<slug>/<slug>-thumbnail.png). Pass only after the file exists; otherwise omit so _includes/testbed.html does not render a broken <img>. The conventional path is /img/<slug>/<slug>-thumbnail.png.",
     )
     parser.add_argument("--date", default="", help="ISO date YYYY-MM-DD; defaults to today")
     args = parser.parse_args(argv)
@@ -238,6 +249,7 @@ def main(argv: list[str] | None = None) -> int:
             date=date,
             root=root,
             at=args.at or None,
+            thumbnail=args.thumbnail or None,
         )
     except (ValueError, FileExistsError) as exc:
         print(str(exc), file=sys.stderr)

--- a/.agents/shared/skills/write-post/scripts/new_post.py
+++ b/.agents/shared/skills/write-post/scripts/new_post.py
@@ -48,8 +48,19 @@ def normalize_emoji(value: str) -> str:
     return f"/emoji/{value}"
 
 
+def yaml_double_quote(value: str) -> str:
+    """Wrap *value* in YAML double quotes, escaping backslashes and quotes.
+
+    YAML double-quoted scalars treat ``\\`` and ``"`` specially, so a raw title
+    like ``Bayes "Rule"`` would otherwise produce ``title: "Bayes "Rule""``,
+    which is rejected by every strict YAML loader (Jekyll's included).
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def frontmatter_note(title: str, emoji: str | None) -> str:
-    lines = ["---", f'title: "{title}"', "layout: post"]
+    lines = ["---", f"title: {yaml_double_quote(title)}", "layout: post"]
     if emoji:
         lines.append(f"emoji: {emoji}")
     lines.append("related: []")
@@ -60,13 +71,13 @@ def frontmatter_note(title: str, emoji: str | None) -> str:
 def frontmatter_testbed(title: str, slug: str, emoji: str | None) -> str:
     lines = [
         "---",
-        f'title: "{title}"',
+        f"title: {yaml_double_quote(title)}",
         "layout: post",
         'hashtag: ""',
         "comment: true",
         "splitter: 2",
         "featured: false",
-        "inprogress: true",
+        "inprogress: false",
         'at: ""',
         f"thumbnail: /img/{slug}/{slug}-thumbnail.png",
     ]

--- a/.agents/shared/skills/write-post/scripts/new_post.py
+++ b/.agents/shared/skills/write-post/scripts/new_post.py
@@ -68,7 +68,9 @@ def frontmatter_note(title: str, emoji: str | None) -> str:
     return "\n".join(lines) + "\n"
 
 
-def frontmatter_testbed(title: str, slug: str, emoji: str | None) -> str:
+def frontmatter_testbed(
+    title: str, slug: str, emoji: str | None, at: str | None = None
+) -> str:
     lines = [
         "---",
         f"title: {yaml_double_quote(title)}",
@@ -78,9 +80,10 @@ def frontmatter_testbed(title: str, slug: str, emoji: str | None) -> str:
         "splitter: 2",
         "featured: false",
         "inprogress: false",
-        'at: ""',
         f"thumbnail: /img/{slug}/{slug}-thumbnail.png",
     ]
+    if at:
+        lines.append(f"at: {yaml_double_quote(at)}")
     if emoji:
         lines.append(f"emoji: {emoji}")
     lines.append("related: []")
@@ -158,6 +161,7 @@ def build_post(
     language: str,
     date: _dt.date,
     root: Path,
+    at: str | None = None,
 ) -> Path:
     if category not in VALID_CATEGORIES:
         raise ValueError(f"category must be one of {VALID_CATEGORIES}, got {category!r}")
@@ -167,6 +171,12 @@ def build_post(
         raise ValueError(f"language must be one of {VALID_LANGUAGES}, got {language!r}")
     if not slug or slug != kebab(slug):
         raise ValueError(f"slug must be kebab-case, got {slug!r}")
+    if category == "note" and (style == "testbed-longform"):
+        raise ValueError("style 'testbed-longform' is only valid for category 'testbed'")
+    if category == "testbed" and style != "testbed-longform":
+        raise ValueError(
+            f"category 'testbed' requires style 'testbed-longform', got {style!r}"
+        )
 
     posts_dir = root / category / "_posts"
     posts_dir.mkdir(parents=True, exist_ok=True)
@@ -179,7 +189,7 @@ def build_post(
     if category == "note":
         fm = frontmatter_note(title, emoji)
     else:
-        fm = frontmatter_testbed(title, slug, emoji)
+        fm = frontmatter_testbed(title, slug, emoji, at=at)
 
     body = BODY_BUILDERS[style]()
 
@@ -199,6 +209,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--style", required=True, choices=VALID_STYLES)
     parser.add_argument("--language", default="en", choices=VALID_LANGUAGES)
     parser.add_argument("--emoji", default="")
+    parser.add_argument(
+        "--at",
+        default="",
+        help="Testbed venue/lab/event (e.g. 'Visual Media Lab'). Omit for none — empty string would render a dangling marker because Liquid treats empty strings as truthy.",
+    )
     parser.add_argument("--date", default="", help="ISO date YYYY-MM-DD; defaults to today")
     args = parser.parse_args(argv)
 
@@ -222,6 +237,7 @@ def main(argv: list[str] | None = None) -> int:
             language=args.language,
             date=date,
             root=root,
+            at=args.at or None,
         )
     except (ValueError, FileExistsError) as exc:
         print(str(exc), file=sys.stderr)

--- a/.agents/shared/skills/write-post/scripts/new_post.py
+++ b/.agents/shared/skills/write-post/scripts/new_post.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Scaffold a new post file with frontmatter and a body wrapper.
+
+The skill workflow uses this to produce a consistent starting file. The body
+wrapper is intentionally minimal — the agent fills it in afterwards. The
+`related:` field is always emitted as an empty list because populating it is
+the responsibility of the `/add-related` skill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+VALID_CATEGORIES = ("note", "testbed")
+VALID_STYLES = ("outline", "prose", "keyword", "testbed-longform")
+VALID_LANGUAGES = ("en", "kr")
+
+
+def repo_root() -> Path:
+    out = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True)
+    return Path(out.strip())
+
+
+def kebab(text: str) -> str:
+    """Convert a free-text topic to a kebab-case slug."""
+    text = text.strip().lower()
+    text = re.sub(r"[\s_]+", "-", text)
+    text = re.sub(r"[^a-z0-9\-]+", "", text)
+    text = re.sub(r"-+", "-", text).strip("-")
+    return text
+
+
+def normalize_emoji(value: str) -> str:
+    """Accept either 'brain.png' or '/emoji/brain.png' and return the path form."""
+    if not value:
+        return ""
+    value = value.strip()
+    if value.startswith("/emoji/"):
+        return value
+    if value.startswith("emoji/"):
+        return "/" + value
+    return f"/emoji/{value}"
+
+
+def frontmatter_note(title: str, emoji: str | None) -> str:
+    lines = ["---", f'title: "{title}"', "layout: post"]
+    if emoji:
+        lines.append(f"emoji: {emoji}")
+    lines.append("related: []")
+    lines.append("---")
+    return "\n".join(lines) + "\n"
+
+
+def frontmatter_testbed(title: str, slug: str, emoji: str | None) -> str:
+    lines = [
+        "---",
+        f'title: "{title}"',
+        "layout: post",
+        'hashtag: ""',
+        "comment: true",
+        "splitter: 2",
+        "featured: false",
+        "inprogress: true",
+        'at: ""',
+        f"thumbnail: /img/{slug}/{slug}-thumbnail.png",
+    ]
+    if emoji:
+        lines.append(f"emoji: {emoji}")
+    lines.append("related: []")
+    lines.append("---")
+    return "\n".join(lines) + "\n"
+
+
+def body_outline() -> str:
+    return (
+        "\n<br>\n\n"
+        "<ul>\n"
+        "    <li>\n"
+        "        Section Title\n"
+        "    </li>\n"
+        "        <ul>\n"
+        "            <li>\n"
+        "                Body.\n"
+        "            </li>\n"
+        "        </ul>\n"
+        "    <br>\n"
+        "</ul>\n\n"
+        "<br><br>\n"
+    )
+
+
+def body_prose() -> str:
+    return (
+        "\n<br>\n\n"
+        '<div style="text-align: justify;">\n\n'
+        "    Body.\n\n"
+        "</div>\n\n"
+        "<br><br>\n"
+    )
+
+
+def body_keyword() -> str:
+    return (
+        "\n<br>\n\n"
+        '<div style="text-align: justify;">\n\n'
+        "    keyword 1\n"
+        "    <br>\n"
+        "    keyword 2\n\n"
+        "</div>\n\n"
+        "<br><br>\n"
+    )
+
+
+def body_testbed_longform() -> str:
+    return (
+        "\n"
+        '<div id="toc"></div>\n\n'
+        "<h3>Introduction</h3>\n"
+        '<div class="article">\n'
+        "    Body.\n"
+        "</div><br><br>\n\n"
+        "<br><br>\n"
+    )
+
+
+BODY_BUILDERS = {
+    "outline": body_outline,
+    "prose": body_prose,
+    "keyword": body_keyword,
+    "testbed-longform": body_testbed_longform,
+}
+
+
+def build_post(
+    *,
+    category: str,
+    slug: str,
+    title: str,
+    style: str,
+    emoji: str | None,
+    language: str,
+    date: _dt.date,
+    root: Path,
+) -> Path:
+    if category not in VALID_CATEGORIES:
+        raise ValueError(f"category must be one of {VALID_CATEGORIES}, got {category!r}")
+    if style not in VALID_STYLES:
+        raise ValueError(f"style must be one of {VALID_STYLES}, got {style!r}")
+    if language not in VALID_LANGUAGES:
+        raise ValueError(f"language must be one of {VALID_LANGUAGES}, got {language!r}")
+    if not slug or slug != kebab(slug):
+        raise ValueError(f"slug must be kebab-case, got {slug!r}")
+
+    posts_dir = root / category / "_posts"
+    posts_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = f"{date.isoformat()}-{slug}.html"
+    target = posts_dir / filename
+    if target.exists():
+        raise FileExistsError(f"refuse to overwrite existing post: {target}")
+
+    if category == "note":
+        fm = frontmatter_note(title, emoji)
+    else:
+        fm = frontmatter_testbed(title, slug, emoji)
+
+    body = BODY_BUILDERS[style]()
+
+    target.write_text(fm + body, encoding="utf-8")
+
+    img_dir = root / "img" / slug
+    img_dir.mkdir(parents=True, exist_ok=True)
+
+    return target
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", required=True, choices=VALID_CATEGORIES)
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--style", required=True, choices=VALID_STYLES)
+    parser.add_argument("--language", default="en", choices=VALID_LANGUAGES)
+    parser.add_argument("--emoji", default="")
+    parser.add_argument("--date", default="", help="ISO date YYYY-MM-DD; defaults to today")
+    args = parser.parse_args(argv)
+
+    root = repo_root()
+    if args.date:
+        try:
+            date = _dt.date.fromisoformat(args.date)
+        except ValueError as exc:
+            print(f"invalid --date: {exc}", file=sys.stderr)
+            return 2
+    else:
+        date = _dt.date.today()
+
+    try:
+        target = build_post(
+            category=args.category,
+            slug=args.slug,
+            title=args.title,
+            style=args.style,
+            emoji=normalize_emoji(args.emoji) if args.emoji else None,
+            language=args.language,
+            date=date,
+            root=root,
+        )
+    except (ValueError, FileExistsError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print(target.relative_to(root))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds a repo-local `write-post` skill that scaffolds and drafts new posts under `note/_posts` or `testbed/_posts` following this repo's frontmatter, body-style, image, and follow-up conventions.
- The skill leaves `related:` empty by contract and delegates that field to `/add-related`. It does not run `build-latentspace` (that is automatic on merge) and it does not create the PR.
- Patterns were extracted from prior post-writing sessions (`limits-of-language`, `window-crossing-selection`, `triangle-menu-aim`, `regression-model`, `ego`, `spurting`, `image-to-3d-scene`) and codified into `references/`.

### Layout

```
.agents/shared/skills/write-post/
├── SKILL.md                    # workflow, args, hard rules
├── references/
│   ├── frontmatter.md          # note/testbed templates
│   ├── body-styles.md          # outline / prose / keyword / testbed-longform
│   ├── images.md               # matplotlib + three.js diagram rules
│   └── examples.md             # slug → category/style mapping
└── scripts/
    └── new_post.py             # file scaffolder + img/<slug>/ creation
```

### Arguments

```
/write-post [topic] [--language=en|kr] [--emoji=<file>] [--sources=<urls,paths>] [--category=note|testbed] [--slug=<slug>]
```

Frontmatter `argument-hint:` is quoted as a single string because a leading `[` would otherwise be parsed as a YAML flow sequence and break Codex's strict YAML loader.

## Test plan

- [ ] Restart the editor session so the skill registry picks up `write-post` (skills are scanned at session start).
- [ ] In a new session, type `/write-post` to confirm the autocomplete hint shows the argument list.
- [ ] Run `/write-post some-topic --category=note --slug=test-slug --language=en` end-to-end and verify the file scaffolds at `note/_posts/<date>-test-slug.html` with `related: []` and that `img/test-slug/` is created.
- [ ] Confirm `bundle exec jekyll build` still succeeds.
- [ ] Discard the test post (`git checkout -- note/_posts/<date>-test-slug.html` and `rm -rf img/test-slug/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)