### PR TITLE
Fix behavior-aware figure framing on mobile and match E camera to D

### DIFF
--- a/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
+++ b/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
@@ -27,6 +27,8 @@ related:
 .viz-scene .lbl.gr { color: #2fa35a; border-color: rgba(47,163,90,.3); }
 .viz-scene .lbl.fb { color: #3a5cc0; border-color: rgba(58,92,192,.3); }
 .viz-scene .lbl.fa { color: #a8752a; border-color: rgba(168,117,42,.3); }
+/* mobile: shorter canvas so wide figures fill it (the camera fits width, so a tall canvas just letterboxes) */
+@media (max-width: 640px) { .viz-scene { height: 260px !important; } }
 </style>
 
 <ul>
@@ -156,7 +158,7 @@ related:
                     <li>
                         Meaningful spatial reasoning emerges when objects are considered as part of behavioral configurations; for example, <strong>chairs around a desk forming a workspace or sofas arranged around a coffee table creating a lounge area</strong>. The <strong>[E] Semantic Grouping</strong> stage identifies both <strong>intra-group spatial relations</strong> (internal arrangement within a functional unit) and <strong>inter-group spatial relations</strong> (connectivity between distinct groups).
                         <figure>
-                            <div class="viz-scene" id="s-grouping" style="height:460px" data-cam="3.2,-5.2,4.8" data-target="0.1,0.9,0.5"></div>
+                            <div class="viz-scene" id="s-grouping" style="height:460px" data-cam="2.66,-3.79,1.83" data-target="0.1,0.9,0.5"></div>
                             <figcaption class="nofig">[E] Semantic Grouping &middot; objects that function together form a group (work / lounge / storage); solid links are intra-group relations, dashed magenta links are inter-group relations.</figcaption>
                         </figure>
                     </li>

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -29,7 +29,7 @@ function boxEdges(w, d, h, color, opacity) {
   g.add(new THREE.LineSegments(new THREE.EdgesGeometry(geo), new THREE.LineBasicMaterial({ color })));
   return g;
 }
-function floorGrid(scene, size) { const g = new THREE.GridHelper(size, size * 4, 0xd7d7d9, 0xededee); g.rotation.x = Math.PI / 2; scene.add(g); return g; }
+function floorGrid(scene, size) { const g = new THREE.GridHelper(size, size * 4, 0xd7d7d9, 0xededee); g.rotation.x = Math.PI / 2; g.userData.isFloor = true; scene.add(g); return g; }
 function label(text, cls, x, y, z) {
   const el = document.createElement('div');
   el.className = 'lbl' + (cls ? ' ' + cls : '');
@@ -297,7 +297,33 @@ function makeScene(container, build) {
   ctr.minZoom = 0.7; ctr.maxZoom = 2.5; // ortho zoom clamps (minDistance/maxDistance are no-ops for OrthographicCamera)
   ctr.target.set(tg[0], tg[1], tg[2]);
   build(scene, THREE, renderer);   // renderer passed so a build can render-to-texture (multi-view capture)
-  if (window.ResizeObserver) new ResizeObserver(() => { const w = container.clientWidth, h = container.clientHeight; if (!w || !h) return; cam.left = -halfH*w/h; cam.right = halfH*w/h; cam.top = halfH; cam.bottom = -halfH; cam.updateProjectionMatrix(); renderer.setSize(w, h); lr.setSize(w, h); }).observe(container);
+  // responsive framing: keep the tuned vertical extent (halfH) on wide screens, but on narrow (mobile)
+  // viewports zoom out so the full content WIDTH still fits — otherwise wide figures get clipped left/right.
+  const target = new THREE.Vector3(tg[0], tg[1], tg[2]);
+  const fwd = new THREE.Vector3().subVectors(target, cam.position).normalize();
+  const right = new THREE.Vector3().crossVectors(fwd, new THREE.Vector3(0, 0, 1)).normalize();
+  // content half-width along the camera's RIGHT axis. Project each mesh's world bounding sphere
+  // (center·right ± radius) instead of an axis-aligned Box3's 8 corners: for a diagonal camera over a
+  // plus-shaped layout (stage B's 4 view planes) the empty AABB corners project onto the 45° right-axis
+  // at ~√2× the true width, which over-zoomed wide figures — worst on mobile, where width binds the fit.
+  scene.updateMatrixWorld(true);
+  const tR = target.dot(right), sph = new THREE.Sphere();
+  let halfW = halfH;
+  scene.traverse(o => {
+    if (o.userData && o.userData.isFloor || !o.geometry) return;   // skip floor grid and label-only nodes
+    if (!o.geometry.boundingSphere) o.geometry.computeBoundingSphere();
+    sph.copy(o.geometry.boundingSphere).applyMatrix4(o.matrixWorld);
+    halfW = Math.max(halfW, Math.abs(sph.center.dot(right) - tR) + sph.radius);
+  });
+  const FIT = 1.22;   // margin so edge labels (CSS2D, wider than their anchor point) aren't clipped
+  function frame() {
+    const w = container.clientWidth, h = container.clientHeight; if (!w || !h) return;
+    const aspect = w / h, hH = Math.max(halfH, halfW * FIT / aspect);
+    cam.left = -hH * aspect; cam.right = hH * aspect; cam.top = hH; cam.bottom = -hH; cam.updateProjectionMatrix();
+    renderer.setSize(w, h); lr.setSize(w, h);
+  }
+  frame();
+  if (window.ResizeObserver) new ResizeObserver(frame).observe(container);
   (function loop() { requestAnimationFrame(loop); if (scene.userData.tick) scene.userData.tick(performance.now()); ctr.update(); renderer.render(scene, cam); lr.render(scene, cam); })();
   return { scene, cam, controls: ctr };
 }


### PR DESCRIPTION
## What

Three figure-presentation fixes for the *Behavior-Aware Anthropometric Scene Generation* post, mostly targeting mobile.

### 1. Responsive fit-to-width framing + correct `halfW` (`threesrc/behavior-aware-conflict.js`)
On narrow viewports the camera now zooms out just enough to fit the content **width**, so wide figures no longer clip left/right.

`halfW` (content half-width) is measured from each mesh's **world bounding sphere** projected onto the camera's right-axis — not an axis-aligned bounding box's 8 corners. For a diagonal camera over a plus-shaped layout (stage B's four view planes), the *empty* AABB corners project onto the 45° right-axis at ~√2× the true width, which over-zoomed the figure — worst on mobile, where width binds the fit.

| Stage B | `halfW` |
|---|---|
| old | ~4.2 (phantom AABB corner) |
| new | ~2.9 (real content) → ~1.4× bigger on mobile |

The sphere projection is a strict *upper bound* on real geometry, so it only removes empty margin — it can never clip content. The floor grid is tagged `isFloor` and excluded from the measurement.

### 2. Mobile canvas height (post `<style>`)
`@media (max-width: 640px) { .viz-scene { height: 260px } }` — a shorter canvas gives a wider aspect, so wide figures fill it instead of letterboxing.

### 3. Match [E] camera to [D] (post HTML)
The [E] Semantic Grouping figure was a steep top-down view; [D] is a low eye-level three-quarter view. Matched E's angle to D and pulled it closer to fill the frame.

| | before | after |
|---|---|---|
| elevation | 32° | 14° (= D) |
| distance | 8.1 | 5.5 (≈ D's 5.2) |
| `data-cam` | `3.2,-5.2,4.8` | `2.66,-3.79,1.83` |

## Verification
- `node --check` on the JS (valid syntax).
- Rendered on the local Jekyll server (`:4000`): B fills the mobile frame, E matches D's angle, all labels readable, no clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)