### PR TITLE
Fix embedding input overflow for long Korean posts

### DIFF
--- a/.agents/shared/INSTRUCTIONS.md
+++ b/.agents/shared/INSTRUCTIONS.md
@@ -41,7 +41,7 @@ python3 .agents/shared/skills/build-latentspace/scripts/build_post_map.py
 Python dependencies for latent-space work are installed in CI with:
 
 ```bash
-pip install openai beautifulsoup4 lxml numpy scikit-learn pytest
+pip install openai beautifulsoup4 lxml numpy scikit-learn pytest tiktoken
 ```
 
 ## Content Conventions

--- a/.agents/shared/hooks/pre-commit-check.sh
+++ b/.agents/shared/hooks/pre-commit-check.sh
@@ -58,8 +58,8 @@ run_latentspace_tests() {
     command -v "$python_bin" >/dev/null 2>&1 || fail "python not found: $python_bin"
 
     echo "[pre-commit] latent-space pytest" >&2
-    if ! (cd "$ROOT" && "$python_bin" -c 'import pytest, openai, numpy, sklearn, bs4' >/dev/null 2>&1); then
-        fail "missing Python deps for latent-space tests; rebuild the devcontainer or set LATENTSPACE_PYTHON to a venv with openai beautifulsoup4 lxml numpy scikit-learn pytest"
+    if ! (cd "$ROOT" && "$python_bin" -c 'import pytest, openai, numpy, sklearn, bs4, tiktoken' >/dev/null 2>&1); then
+        fail "missing Python deps for latent-space tests; rebuild the devcontainer or set LATENTSPACE_PYTHON to a venv with openai beautifulsoup4 lxml numpy scikit-learn pytest tiktoken"
     fi
 
     (cd "$ROOT" && "$python_bin" -m pytest "$test_file" -v) >&2 || fail "latent-space tests failed"

--- a/.agents/shared/skills/build-latentspace/SKILL.md
+++ b/.agents/shared/skills/build-latentspace/SKILL.md
@@ -23,7 +23,7 @@ Incremental mode: cached embeddings in `data/embeddings.json` avoid repeat OpenA
 ## Prerequisites
 
 - `OPENAI_API_KEY` environment variable must be set
-- Python dependencies: `openai`, `beautifulsoup4`, `lxml`, `numpy`, `scikit-learn`
+- Python dependencies: `openai`, `beautifulsoup4`, `lxml`, `numpy`, `scikit-learn`, `tiktoken`
 
 ## Run
 

--- a/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
@@ -114,6 +114,12 @@ EMBED_MODEL = "text-embedding-3-small"
 EMBED_TOKEN_LIMIT = 8192
 EMBED_TOKEN_MARGIN = 500
 
+# The API also caps the total tokens across all inputs in a single request at
+# 300k, independent of the 8192 per-input cap. Requests are batched to stay
+# under it; the margin leaves room for one max-size chunk of counting slack.
+EMBED_REQUEST_TOKEN_LIMIT = 300_000
+EMBED_REQUEST_TOKEN_MARGIN = 8_192
+
 _ENCODING = None
 
 
@@ -156,6 +162,23 @@ def _pool_chunk_embeddings(chunk_vectors, chunk_token_lens):
     if norm > 0:  # numerical guard; real chunk embeddings never sum to zero
         pooled = pooled / norm
     return pooled
+
+
+def _batch_indices_by_tokens(token_lens, budget):
+    """Group chunk indices into batches whose token sums each stay under budget.
+
+    Each chunk is already under the per-input cap (well below budget), so every
+    batch holds at least one chunk and no batch exceeds the budget.
+    """
+    batch, batch_tokens = [], 0
+    for i, tokens in enumerate(token_lens):
+        if batch and batch_tokens + tokens > budget:
+            yield batch
+            batch, batch_tokens = [], 0
+        batch.append(i)
+        batch_tokens += tokens
+    if batch:
+        yield batch
 
 
 def load_posts():
@@ -211,24 +234,31 @@ def get_embeddings(posts, client):
     """Batch embed posts via OpenAI API, one vector per post.
 
     Each post carries one or more chunks (multiple only when its text exceeds
-    the token budget). All chunks across all posts go out in a single batch
-    call; a post's chunk vectors are then pooled back into one vector, so the
-    output stays 1:1 with posts and the per-input token limit is respected.
+    the token budget). Chunks across all posts are sent in as few requests as
+    the aggregate per-request token cap allows; a post's chunk vectors are then
+    pooled back into one vector, so the output stays 1:1 with posts and both
+    the per-input and per-request token limits are respected.
     """
     all_chunks = []
+    chunk_token_lens = []
     spans = []  # (start index into all_chunks, [token length per chunk]) per post
     for post in posts:
         chunks = post["embed_chunks"]
         token_lens = [len(_encoding().encode(c)) for c in chunks]
         spans.append((len(all_chunks), token_lens))
         all_chunks.extend(chunks)
+        chunk_token_lens.extend(token_lens)
 
     print(f"Embedding {len(posts)} posts ({len(all_chunks)} chunks)...")
-    response = client.embeddings.create(
-        model=EMBED_MODEL,
-        input=all_chunks,
-    )
-    chunk_vectors = [item.embedding for item in response.data]
+    chunk_vectors = [None] * len(all_chunks)
+    budget = EMBED_REQUEST_TOKEN_LIMIT - EMBED_REQUEST_TOKEN_MARGIN
+    for batch in _batch_indices_by_tokens(chunk_token_lens, budget):
+        response = client.embeddings.create(
+            model=EMBED_MODEL,
+            input=[all_chunks[i] for i in batch],
+        )
+        for i, item in zip(batch, response.data):
+            chunk_vectors[i] = item.embedding
 
     embeddings = []
     for start, token_lens in spans:

--- a/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
@@ -107,7 +107,9 @@ def strip_html(html_text):
 # text-embedding-3-small rejects inputs over 8192 tokens. Character-count
 # heuristics undercount dense-tokenizing text (compatibility jamo like
 # "ㅋ", emoji, digit runs), so the budget is enforced with the model's own
-# tokenizer.
+# tokenizer. Over-budget posts are split into chunks and pooled into one
+# vector (OpenAI cookbook "embedding long inputs" pattern) rather than
+# truncated, so the whole post is represented instead of just its head.
 EMBED_MODEL = "text-embedding-3-small"
 EMBED_TOKEN_LIMIT = 8192
 EMBED_TOKEN_MARGIN = 500
@@ -122,17 +124,38 @@ def _encoding():
     return _ENCODING
 
 
-def clip_to_token_limit(text, limit=EMBED_TOKEN_LIMIT - EMBED_TOKEN_MARGIN):
-    """Trim text to the embedding input token budget, counted exactly.
+def chunk_to_token_limit(text, limit=EMBED_TOKEN_LIMIT - EMBED_TOKEN_MARGIN):
+    """Split text into consecutive chunks that each fit the token budget.
 
-    Texts already under the limit are returned unchanged so cached
-    embeddings keyed on embed_text stay valid. A token slice can split a
-    multi-byte character, so any replacement char at the cut is stripped.
+    Text already within budget is returned as a single-element list holding
+    the original string unchanged, so cached embeddings for existing posts
+    stay valid. A token slice can split a multi-byte character, so any
+    replacement char at a chunk boundary is stripped.
     """
     tokens = _encoding().encode(text)
     if len(tokens) <= limit:
-        return text
-    return _encoding().decode(tokens[:limit]).rstrip("�")
+        return [text]
+    # lazy: fixed-size token windows; no sentence-boundary or overlap logic —
+    # a blended theme vector for the 2D map does not need boundary fidelity.
+    return [
+        _encoding().decode(tokens[i:i + limit]).strip("�")
+        for i in range(0, len(tokens), limit)
+    ]
+
+
+def _pool_chunk_embeddings(chunk_vectors, chunk_token_lens):
+    """Combine a post's chunk embeddings into one vector.
+
+    Token-length-weighted mean (longer chunks carry proportionally more
+    weight), then L2-renormalized back onto the unit sphere so the pooled
+    vector stays comparable with single-chunk embeddings, which the API
+    already returns at unit norm. (OpenAI cookbook pattern.)
+    """
+    pooled = np.average(np.array(chunk_vectors), axis=0, weights=chunk_token_lens)
+    norm = np.linalg.norm(pooled)
+    if norm > 0:  # numerical guard; real chunk embeddings never sum to zero
+        pooled = pooled / norm
+    return pooled
 
 
 def load_posts():
@@ -169,7 +192,7 @@ def load_posts():
                 label = "Testbed" if category == "testbed" else "Note"
 
             clean_text = strip_html(body)
-            embed_text = clip_to_token_limit(f"{title}. {clean_text}"[:32000])
+            embed_chunks = chunk_to_token_limit(f"{title}. {clean_text}")
 
             posts.append({
                 "title": title,
@@ -178,21 +201,42 @@ def load_posts():
                 "category": category,
                 "label": label,
                 "connected": fm.get("related", []),
-                "embed_text": embed_text,
+                "embed_chunks": embed_chunks,
             })
 
     return posts
 
 
 def get_embeddings(posts, client):
-    """Batch embed posts via OpenAI API."""
-    texts = [p["embed_text"] for p in posts]
-    print(f"Embedding {len(texts)} posts...")
+    """Batch embed posts via OpenAI API, one vector per post.
+
+    Each post carries one or more chunks (multiple only when its text exceeds
+    the token budget). All chunks across all posts go out in a single batch
+    call; a post's chunk vectors are then pooled back into one vector, so the
+    output stays 1:1 with posts and the per-input token limit is respected.
+    """
+    all_chunks = []
+    spans = []  # (start index into all_chunks, [token length per chunk]) per post
+    for post in posts:
+        chunks = post["embed_chunks"]
+        token_lens = [len(_encoding().encode(c)) for c in chunks]
+        spans.append((len(all_chunks), token_lens))
+        all_chunks.extend(chunks)
+
+    print(f"Embedding {len(posts)} posts ({len(all_chunks)} chunks)...")
     response = client.embeddings.create(
         model=EMBED_MODEL,
-        input=texts,
+        input=all_chunks,
     )
-    embeddings = [item.embedding for item in response.data]
+    chunk_vectors = [item.embedding for item in response.data]
+
+    embeddings = []
+    for start, token_lens in spans:
+        vectors = chunk_vectors[start:start + len(token_lens)]
+        if len(vectors) == 1:
+            embeddings.append(np.array(vectors[0]))
+        else:
+            embeddings.append(_pool_chunk_embeddings(vectors, token_lens))
     print(f"Got {len(embeddings)} embeddings, dim={len(embeddings[0])}")
     return np.array(embeddings)
 

--- a/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
@@ -103,6 +103,39 @@ def strip_html(html_text):
     return text
 
 
+# text-embedding-3-small rejects inputs over 8192 tokens. CJK text tokenizes
+# at roughly 2 tokens per character, so a flat character cap cannot hold the
+# limit for Korean posts.
+EMBED_TOKEN_LIMIT = 8192
+EMBED_TOKEN_MARGIN = 500
+
+
+def estimate_tokens(text):
+    # lazy: conservative char-class heuristic (CJK 2.5 tok/char, other 1 tok
+    # per 3.5 chars); swap for tiktoken if exact budgeting ever matters
+    cjk = sum(
+        1
+        for c in text
+        if "가" <= c <= "힣"  # Hangul syllables
+        or "ᄀ" <= c <= "ᇿ"  # Hangul jamo
+        or "぀" <= c <= "ヿ"  # Kana
+        or "一" <= c <= "鿿"  # CJK ideographs
+    )
+    other = len(text) - cjk
+    return int(cjk * 2.5 + other / 3.5)
+
+
+def clip_to_token_limit(text, limit=EMBED_TOKEN_LIMIT - EMBED_TOKEN_MARGIN):
+    """Trim text until the token estimate fits the embedding input limit.
+
+    Texts already under the limit are returned unchanged so cached
+    embeddings keyed on embed_text stay valid.
+    """
+    while estimate_tokens(text) > limit:
+        text = text[: int(len(text) * 0.9)]
+    return text
+
+
 def load_posts():
     """Load all eligible posts from note/_posts and testbed/_posts."""
     patterns = [
@@ -137,7 +170,7 @@ def load_posts():
                 label = "Testbed" if category == "testbed" else "Note"
 
             clean_text = strip_html(body)
-            embed_text = f"{title}. {clean_text}"[:32000]
+            embed_text = clip_to_token_limit(f"{title}. {clean_text}"[:32000])
 
             posts.append({
                 "title": title,

--- a/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
@@ -280,8 +280,19 @@ def main():
 
     # Load cached embeddings to avoid redundant API calls
     cached_embeddings = load_cached_embeddings()
-    new_slugs = [p["slug"] for p in posts if p["slug"] not in cached_embeddings]
-    cached_slugs = [p["slug"] for p in posts if p["slug"] in cached_embeddings]
+
+    # Reuse a cached vector only when it can be trusted from the slug alone.
+    # Single-chunk posts qualify: their embedding input is the verbatim post
+    # text, so the cached vector still matches. Multi-chunk posts do not — their
+    # vector is a pooled average that depends on the current chunking, so an
+    # entry cached under an older algorithm (e.g. truncation) is stale. There
+    # are only a handful of multi-chunk posts and each is a few cheap chunk
+    # embeds, so recompute them every run.
+    def _is_stale(post):
+        return post["slug"] not in cached_embeddings or len(post["embed_chunks"]) > 1
+
+    new_slugs = [p["slug"] for p in posts if _is_stale(p)]
+    cached_slugs = [p["slug"] for p in posts if not _is_stale(p)]
 
     print(f"Cached: {len(cached_slugs)}, New: {len(new_slugs)}")
 

--- a/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/build_post_map.py
@@ -18,6 +18,7 @@ from bs4 import BeautifulSoup
 from openai import OpenAI
 from sklearn.decomposition import PCA
 import numpy as np
+import tiktoken
 
 EMOJI_TO_LABEL = {
     "brain": "Brain",
@@ -103,37 +104,35 @@ def strip_html(html_text):
     return text
 
 
-# text-embedding-3-small rejects inputs over 8192 tokens. CJK text tokenizes
-# at roughly 2 tokens per character, so a flat character cap cannot hold the
-# limit for Korean posts.
+# text-embedding-3-small rejects inputs over 8192 tokens. Character-count
+# heuristics undercount dense-tokenizing text (compatibility jamo like
+# "ㅋ", emoji, digit runs), so the budget is enforced with the model's own
+# tokenizer.
+EMBED_MODEL = "text-embedding-3-small"
 EMBED_TOKEN_LIMIT = 8192
 EMBED_TOKEN_MARGIN = 500
 
+_ENCODING = None
 
-def estimate_tokens(text):
-    # lazy: conservative char-class heuristic (CJK 2.5 tok/char, other 1 tok
-    # per 3.5 chars); swap for tiktoken if exact budgeting ever matters
-    cjk = sum(
-        1
-        for c in text
-        if "가" <= c <= "힣"  # Hangul syllables
-        or "ᄀ" <= c <= "ᇿ"  # Hangul jamo
-        or "぀" <= c <= "ヿ"  # Kana
-        or "一" <= c <= "鿿"  # CJK ideographs
-    )
-    other = len(text) - cjk
-    return int(cjk * 2.5 + other / 3.5)
+
+def _encoding():
+    global _ENCODING
+    if _ENCODING is None:
+        _ENCODING = tiktoken.encoding_for_model(EMBED_MODEL)
+    return _ENCODING
 
 
 def clip_to_token_limit(text, limit=EMBED_TOKEN_LIMIT - EMBED_TOKEN_MARGIN):
-    """Trim text until the token estimate fits the embedding input limit.
+    """Trim text to the embedding input token budget, counted exactly.
 
     Texts already under the limit are returned unchanged so cached
-    embeddings keyed on embed_text stay valid.
+    embeddings keyed on embed_text stay valid. A token slice can split a
+    multi-byte character, so any replacement char at the cut is stripped.
     """
-    while estimate_tokens(text) > limit:
-        text = text[: int(len(text) * 0.9)]
-    return text
+    tokens = _encoding().encode(text)
+    if len(tokens) <= limit:
+        return text
+    return _encoding().decode(tokens[:limit]).rstrip("�")
 
 
 def load_posts():
@@ -190,7 +189,7 @@ def get_embeddings(posts, client):
     texts = [p["embed_text"] for p in posts]
     print(f"Embedding {len(texts)} posts...")
     response = client.embeddings.create(
-        model="text-embedding-3-small",
+        model=EMBED_MODEL,
         input=texts,
     )
     embeddings = [item.embedding for item in response.data]

--- a/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
@@ -36,7 +36,7 @@ def _fake_posts(slugs):
             "category": "note",
             "label": "Note",
             "connected": [],
-            "embed_text": f"text for {s}",
+            "embed_chunks": [f"text for {s}"],
         }
         for s in slugs
     ]
@@ -239,40 +239,100 @@ class TestCacheSkip:
         assert len(mock_embed.call_args[0][0]) == len(slugs)
 
 
-class TestClipToTokenLimit:
-    """Embedding inputs must stay under the 8192-token API limit, counted
-    with the model's own tokenizer. Char-count heuristics undercount
-    dense-tokenizing text (compatibility jamo, emoji, digit runs) — found
-    by review reproduction on PR #87."""
+class TestChunkToTokenLimit:
+    """Over-budget inputs are split into chunks that each stay under the
+    8192-token API limit, counted with the model's own tokenizer. Char-count
+    heuristics undercount dense-tokenizing text (compatibility jamo, emoji,
+    digit runs) — found by review reproduction on PR #87. Chunking replaces
+    truncation so the whole post is embedded, not just its head."""
 
     def _count(self, text):
         return len(bpm._encoding().encode(text))
 
-    def test_long_korean_text_is_clipped_under_limit(self):
+    def test_long_korean_text_splits_into_under_limit_chunks(self):
         text = "진실은 투명하게 전달되지 않는다 " * 2000
-        clipped = bpm.clip_to_token_limit(text)
-        assert len(clipped) < len(text)
-        assert self._count(clipped) <= bpm.EMBED_TOKEN_LIMIT - bpm.EMBED_TOKEN_MARGIN
+        chunks = bpm.chunk_to_token_limit(text)
+        assert len(chunks) >= 2
+        for c in chunks:
+            assert self._count(c) <= bpm.EMBED_TOKEN_LIMIT
 
-    def test_compatibility_jamo_text_is_clipped_under_limit(self):
+    def test_compatibility_jamo_text_splits_into_under_limit_chunks(self):
         text = "ㅋ" * 32000
-        clipped = bpm.clip_to_token_limit(text)
-        assert self._count(clipped) <= bpm.EMBED_TOKEN_LIMIT - bpm.EMBED_TOKEN_MARGIN
+        chunks = bpm.chunk_to_token_limit(text)
+        assert len(chunks) >= 2
+        for c in chunks:
+            assert self._count(c) <= bpm.EMBED_TOKEN_LIMIT
 
-    def test_clipped_text_is_prefix_of_original(self):
+    def test_chunks_keep_head_and_tail(self):
+        # the point of chunking over truncation: coverage beyond the first window
         text = "우리는 스스로 거짓의 세계를 만든다 " * 2000
-        clipped = bpm.clip_to_token_limit(text)
-        assert text.startswith(clipped)
+        chunks = bpm.chunk_to_token_limit(text)
+        assert len(chunks) >= 2
+        assert text.startswith(chunks[0])                 # first chunk is a head prefix
+        assert sum(len(c) for c in chunks) > len(chunks[0])  # tail is kept, not discarded
 
-    def test_short_mixed_text_unchanged(self):
+    def test_short_mixed_text_is_single_unchanged_chunk(self):
         text = "some truth. 진실은 순수한 상태로 남아있지 않는다."
-        assert bpm.clip_to_token_limit(text) == text
+        assert bpm.chunk_to_token_limit(text) == [text]
 
-    def test_long_text_under_limit_unchanged(self):
+    def test_long_text_under_limit_is_single_unchanged_chunk(self):
         # long-but-under-budget input must stay byte-identical so cached
         # embeddings for existing posts remain valid
         text = "word " * 4000
-        assert bpm.clip_to_token_limit(text) == text
+        assert bpm.chunk_to_token_limit(text) == [text]
+
+
+class TestChunkPooling:
+    """Disconfirming test for method 2: an over-budget post must embed to the
+    token-weighted mean of ALL its chunk vectors (L2-renormalized), not to just
+    its first chunk (which is what truncation produced)."""
+
+    def test_over_limit_post_pools_weighted_average_not_first_chunk(self):
+        budget = bpm.EMBED_TOKEN_LIMIT - bpm.EMBED_TOKEN_MARGIN
+        text = "word " * (budget + 2000)  # comfortably past one window
+        chunks = bpm.chunk_to_token_limit(text)
+        assert len(chunks) >= 2, "test needs a multi-chunk post"
+
+        enc = bpm._encoding()
+        token_lens = [len(enc.encode(c)) for c in chunks]
+        # a distinct, non-zero vector per chunk so the weighted mean is unambiguous
+        fake_vectors = [
+            [float(i + 1), float((i + 1) ** 2), 1.0, -float(i + 1)]
+            for i in range(len(chunks))
+        ]
+
+        class FakeEmbeddings:
+            def create(self, model, input):
+                assert len(input) == len(chunks)
+                return SimpleNamespace(
+                    data=[SimpleNamespace(embedding=v) for v in fake_vectors]
+                )
+
+        client = SimpleNamespace(embeddings=FakeEmbeddings())
+        result = bpm.get_embeddings([{"slug": "big", "embed_chunks": chunks}], client)
+
+        expected = np.average(np.array(fake_vectors), axis=0, weights=token_lens)
+        expected = expected / np.linalg.norm(expected)
+
+        assert result.shape == (1, 4)
+        np.testing.assert_allclose(result[0], expected, rtol=1e-6, atol=1e-9)
+        # truncation would have returned the first chunk's vector — it must NOT
+        assert not np.allclose(result[0], fake_vectors[0])
+
+    def test_under_limit_post_passes_embedding_through_unchanged(self):
+        # single-chunk posts get the API vector verbatim (no renorm drift), so
+        # existing cached posts keep identical coordinates
+        chunks = bpm.chunk_to_token_limit("a short post")
+        assert chunks == ["a short post"]
+        raw = [0.3, 0.4, 0.5, 0.6]  # deliberately non-unit
+
+        class FakeEmbeddings:
+            def create(self, model, input):
+                return SimpleNamespace(data=[SimpleNamespace(embedding=raw)])
+
+        client = SimpleNamespace(embeddings=FakeEmbeddings())
+        result = bpm.get_embeddings([{"slug": "small", "embed_chunks": chunks}], client)
+        np.testing.assert_array_equal(result[0], np.array(raw))
 
 
 class TestEmbeddingInputBoundary:

--- a/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
@@ -238,6 +238,34 @@ class TestCacheSkip:
         mock_embed.assert_called_once()
         assert len(mock_embed.call_args[0][0]) == len(slugs)
 
+    def test_cached_multichunk_post_is_reembedded(self, tmp_data_dir):
+        """A cached post that is multi-chunk must still be re-embedded: its
+        pooled vector depends on the current chunking, so a slug-only cache
+        entry (e.g. one made under the old truncation) is stale. The cached
+        single-chunk companion must stay cached. Reproduced-bug, PR #87 round 1."""
+        cache = {
+            "mathy": np.random.randn(FAKE_DIM).tolist(),
+            "solo": np.random.randn(FAKE_DIM).tolist(),
+        }
+        with open(tmp_data_dir / "embeddings.json", "w") as f:
+            json.dump(cache, f)
+
+        multichunk = {
+            "title": "Post mathy", "slug": "mathy", "url": "/mathy/",
+            "category": "note", "label": "Note", "connected": [],
+            "embed_chunks": ["chunk one", "chunk two"],
+        }
+        singlechunk = _fake_posts(["solo"])[0]  # embed_chunks == ["text for solo"]
+
+        mock_client = MagicMock()
+        with patch.object(bpm, "load_posts", return_value=[multichunk, singlechunk]), \
+             patch.object(bpm, "get_embeddings", return_value=_fake_embedding(1)) as mock_embed, \
+             patch.object(bpm, "OpenAI", return_value=mock_client):
+            bpm.main()
+
+        mock_embed.assert_called_once()
+        assert [p["slug"] for p in mock_embed.call_args[0][0]] == ["mathy"]
+
 
 class TestChunkToTokenLimit:
     """Over-budget inputs are split into chunks that each stay under the

--- a/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
@@ -236,3 +236,34 @@ class TestCacheSkip:
 
         mock_embed.assert_called_once()
         assert len(mock_embed.call_args[0][0]) == len(slugs)
+
+
+class TestClipToTokenLimit:
+    """Embedding inputs must stay under the 8192-token API limit (issue: long
+    Korean posts blew past it because the old cap counted characters)."""
+
+    def test_long_korean_text_is_clipped_under_limit(self):
+        text = "진실은 투명하게 전달되지 않는다 " * 2000
+        clipped = bpm.clip_to_token_limit(text)
+        assert len(clipped) < len(text)
+        assert bpm.estimate_tokens(clipped) <= bpm.EMBED_TOKEN_LIMIT - bpm.EMBED_TOKEN_MARGIN
+
+    def test_clipped_text_is_prefix_of_original(self):
+        text = "우리는 스스로 거짓의 세계를 만든다 " * 2000
+        clipped = bpm.clip_to_token_limit(text)
+        assert text.startswith(clipped)
+
+    def test_short_mixed_text_unchanged(self):
+        text = "some truth. 진실은 순수한 상태로 남아있지 않는다."
+        assert bpm.clip_to_token_limit(text) == text
+
+    def test_long_english_text_under_limit_unchanged(self):
+        # ~20K ascii chars ≈ 5.7K estimated tokens: must stay byte-identical
+        # so cached embeddings for existing English posts remain valid.
+        text = "a" * 20000
+        assert bpm.clip_to_token_limit(text) == text
+
+    def test_estimate_counts_cjk_heavier_than_ascii(self):
+        korean = "가" * 100
+        ascii_ = "a" * 100
+        assert bpm.estimate_tokens(korean) > bpm.estimate_tokens(ascii_)

--- a/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
@@ -6,6 +6,7 @@ Guards against unnecessary OpenAI API calls (= real money).
 import json
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import numpy as np
@@ -239,14 +240,24 @@ class TestCacheSkip:
 
 
 class TestClipToTokenLimit:
-    """Embedding inputs must stay under the 8192-token API limit (issue: long
-    Korean posts blew past it because the old cap counted characters)."""
+    """Embedding inputs must stay under the 8192-token API limit, counted
+    with the model's own tokenizer. Char-count heuristics undercount
+    dense-tokenizing text (compatibility jamo, emoji, digit runs) — found
+    by review reproduction on PR #87."""
+
+    def _count(self, text):
+        return len(bpm._encoding().encode(text))
 
     def test_long_korean_text_is_clipped_under_limit(self):
         text = "진실은 투명하게 전달되지 않는다 " * 2000
         clipped = bpm.clip_to_token_limit(text)
         assert len(clipped) < len(text)
-        assert bpm.estimate_tokens(clipped) <= bpm.EMBED_TOKEN_LIMIT - bpm.EMBED_TOKEN_MARGIN
+        assert self._count(clipped) <= bpm.EMBED_TOKEN_LIMIT - bpm.EMBED_TOKEN_MARGIN
+
+    def test_compatibility_jamo_text_is_clipped_under_limit(self):
+        text = "ㅋ" * 32000
+        clipped = bpm.clip_to_token_limit(text)
+        assert self._count(clipped) <= bpm.EMBED_TOKEN_LIMIT - bpm.EMBED_TOKEN_MARGIN
 
     def test_clipped_text_is_prefix_of_original(self):
         text = "우리는 스스로 거짓의 세계를 만든다 " * 2000
@@ -257,13 +268,49 @@ class TestClipToTokenLimit:
         text = "some truth. 진실은 순수한 상태로 남아있지 않는다."
         assert bpm.clip_to_token_limit(text) == text
 
-    def test_long_english_text_under_limit_unchanged(self):
-        # ~20K ascii chars ≈ 5.7K estimated tokens: must stay byte-identical
-        # so cached embeddings for existing English posts remain valid.
-        text = "a" * 20000
+    def test_long_text_under_limit_unchanged(self):
+        # long-but-under-budget input must stay byte-identical so cached
+        # embeddings for existing posts remain valid
+        text = "word " * 4000
         assert bpm.clip_to_token_limit(text) == text
 
-    def test_estimate_counts_cjk_heavier_than_ascii(self):
-        korean = "가" * 100
-        ascii_ = "a" * 100
-        assert bpm.estimate_tokens(korean) > bpm.estimate_tokens(ascii_)
+
+class TestEmbeddingInputBoundary:
+    """End-to-end guard at the API boundary: whatever load_posts() produces,
+    main() must hand the embeddings client inputs under the token limit.
+    (Adapted from the PR #87 review reproduction artifact.)"""
+
+    def test_dense_post_reaches_client_under_limit(self, tmp_path):
+        post_dir = tmp_path / "note" / "_posts"
+        post_dir.mkdir(parents=True)
+        (post_dir / "2026-01-01-dense.html").write_text(
+            "---\ntitle: dense\n---\n<p>" + ("ㅋ" * 32000) + "</p>\n",
+            encoding="utf-8",
+        )
+        (post_dir / "2026-01-02-tiny.html").write_text(
+            "---\ntitle: tiny\n---\n<p>short body</p>\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "data").mkdir()
+
+        seen = []
+
+        class FakeEmbeddings:
+            def create(self, model, input):
+                seen.extend(input)
+                return SimpleNamespace(
+                    data=[SimpleNamespace(embedding=[float(i), 1.0 - i]) for i, _ in enumerate(input)]
+                )
+
+        fake_client = SimpleNamespace(embeddings=FakeEmbeddings())
+
+        with patch.object(bpm, "REPO_ROOT", str(tmp_path)), \
+             patch.object(bpm, "DATA_DIR", str(tmp_path / "data")), \
+             patch.object(bpm, "EMBEDDINGS_PATH", str(tmp_path / "data" / "embeddings.json")), \
+             patch.object(bpm, "LATENTSPACE_PATH", str(tmp_path / "data" / "latentspace.json")), \
+             patch.object(bpm, "OpenAI", return_value=fake_client):
+            bpm.main()
+
+        assert seen, "embedding client was never called"
+        enc = bpm._encoding()
+        assert all(len(enc.encode(t)) <= bpm.EMBED_TOKEN_LIMIT for t in seen)

--- a/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
+++ b/.agents/shared/skills/build-latentspace/scripts/test_build_post_map.py
@@ -402,3 +402,39 @@ class TestEmbeddingInputBoundary:
         assert seen, "embedding client was never called"
         enc = bpm._encoding()
         assert all(len(enc.encode(t)) <= bpm.EMBED_TOKEN_LIMIT for t in seen)
+
+
+class TestRequestTokenBudget:
+    """The API caps total tokens across all inputs in one request (300k),
+    separate from the per-input cap. get_embeddings must split chunks across
+    requests so no single call exceeds that cap. Reproduced-bug, PR #87 round 2."""
+
+    def test_chunks_split_across_requests_each_under_budget(self):
+        enc = bpm._encoding()
+        posts = [
+            {"slug": f"p{i}", "embed_chunks": [f"post number {i} " * 50]}
+            for i in range(4)
+        ]
+        per = [len(enc.encode(p["embed_chunks"][0])) for p in posts]
+        budget = per[0] + per[1] + 1  # fits ~2 posts per request, forcing a split
+
+        calls = []
+
+        class FakeEmbeddings:
+            def create(self, model, input):
+                calls.append(list(input))
+                return SimpleNamespace(
+                    data=[SimpleNamespace(embedding=[1.0, 2.0, 3.0, 4.0]) for _ in input]
+                )
+
+        client = SimpleNamespace(embeddings=FakeEmbeddings())
+        with patch.object(bpm, "EMBED_REQUEST_TOKEN_LIMIT", budget), \
+             patch.object(bpm, "EMBED_REQUEST_TOKEN_MARGIN", 0):
+            result = bpm.get_embeddings(posts, client)
+
+        assert len(calls) >= 2, "expected multiple requests under the token budget"
+        for inputs in calls:
+            assert sum(len(enc.encode(t)) for t in inputs) <= budget
+        # every chunk still embedded, one vector per post
+        assert sorted(t for c in calls for t in c) == sorted(p["embed_chunks"][0] for p in posts)
+        assert result.shape == (4, 4)

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,7 +20,8 @@ RUN python3 -m venv /opt/latentspace-venv \
     lxml \
     numpy \
     scikit-learn \
-    pytest
+    pytest \
+    tiktoken
 
 ENV LATENTSPACE_PYTHON=/opt/latentspace-venv/bin/python
 

--- a/.github/workflows/build-latentspace.yml
+++ b/.github/workflows/build-latentspace.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install openai beautifulsoup4 lxml numpy scikit-learn pytest
+        run: pip install openai beautifulsoup4 lxml numpy scikit-learn pytest tiktoken
 
       - name: Run tests
         run: python3 -m pytest .agents/shared/skills/build-latentspace/scripts/test_build_post_map.py -v


### PR DESCRIPTION
## Description
**TL;DR:** Long posts were truncated before embedding — Korean ≈ 2 tokens/char, so the old `[:32000]` char cap silently dropped the tail. Now an over-budget post is chunked, each chunk embedded, and the chunks pooled into one full-text vector.
- 🔧 Embedding: `chunk_to_token_limit` + `_pool_chunk_embeddings` (token-weighted mean → L2 renorm) replace truncation, so every token is embedded into one vector per post.
- 🧩 Robustness: `_batch_indices_by_tokens` keeps each request under the 300k aggregate token cap; multi-chunk posts are re-embedded so a stale slug-cache can't serve a truncated vector.
- 📦 Deps + tests: propagate the new `tiktoken` dependency to CI, the pre-commit probe, SKILL.md, INSTRUCTIONS.md and the devcontainer venv; 20 tests incl. disconfirming cases.

## Flow
```mermaid
flowchart LR
  A[post text] --> B{tokens > 7692?}
  B -->|no| C[embed as-is]
  B -->|yes| D[split into chunks]
  D --> E[embed each, batched < 300k/req]
  E --> F[weighted mean + L2 renorm]
  C --> G[one vector per post]
  F --> G
```

## Before / After
| Before — truncate | After — chunk + pool |
|---|---|
| char cap `[:32000]`, then keep 7,692 tokens | tiktoken-exact chunks, every token embedded |
| `some-truth`: 7,692 / 8,966 tokens, ~14% tail dropped | `some-truth`: 2 chunks `[7692, 1273]`, full text |
| one request for all inputs | split so each request < 300k tokens |
| cached over-limit post keeps stale vector | multi-chunk posts always re-embedded |

<sub>Data-pipeline change (no UI) — Mermaid + data table by design.</sub>
