### PR TITLE
Fix broken images on layout-vlm and resolve Git LFS at publish time

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; never cancel an in-flight publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # GitHub Pages cannot serve Git LFS files, so the legacy branch build
+          # published 132-byte pointer files instead of the images. Resolving
+          # them here is the whole reason this workflow exists.
+          lfs: true
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.11'
+          bundler-cache: true
+
+      - uses: actions/configure-pages@v5
+
+      - run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/note/_posts/2025-08-04-layout-vlm.html
+++ b/note/_posts/2025-08-04-layout-vlm.html
@@ -31,13 +31,13 @@ related:
                         As part of our research to improve our LLM-based product at Spacewalk for furniture placement in apartments and houses, I will review this paper.
                         The method used in the LayoutVLM paper is similar to ours, so I hope to understand the differences and gain insights.
                         <figure style="display: flex;">
-                            <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-1.gif" width="40%" onerror==handle_image_error(this)>
-                            <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-2.gif" width="50%" onerror==handle_image_error(this)>
+                            <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-1.gif" width="40%" onerror="handle_image_error(this)">
+                            <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-2.gif" width="50%" onerror="handle_image_error(this)">
                         </figure>
                         <figcaption>LayoutVLM Demo</figcaption>
                         <br>
                         <figure>
-                            <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-0.gif" width="100%" onerror==handle_image_error(this)>
+                            <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-0.gif" width="100%" onerror="handle_image_error(this)">
                         </figure>
                         <br>
                         <figcaption>Spacewalk's PoC for LLM-based furniture placement</figcaption>
@@ -153,7 +153,7 @@ related:
                         \(\hat{p}_{i=1}^{\tiny{N}} \), as well as a set of spatial relations between assets (and walls).
                         
                         <figure>
-                            <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-3.png" width="100%" onerror==handle_image_error(this)>
+                            <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-3.png" width="100%" onerror="handle_image_error(this)">
                         </figure>
                         <figcaption>Process of generating 3D scene layout with Vision-Language Models</figcaption>
                     </li>
@@ -192,8 +192,8 @@ related:
                                     initialization can lead to a suboptimal layout
                                 </mark>
                                 <figure style="display: flex;">
-                                    <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-4.png" width="40%" onerror==handle_image_error(this)>
-                                    <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-5.png" width="40%" onerror==handle_image_error(this)>
+                                    <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-4.png" width="40%" onerror="handle_image_error(this)">
+                                    <img alt="LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models" src="/img/layout-vlm/layout-vlm-5.png" width="40%" onerror="handle_image_error(this)">
                                 </figure> 
                                 <figcaption>Example Scene Representation</figcaption>
                             </li>


### PR DESCRIPTION
## Symptom

Every image on [`/layout-vlm/`](https://parkcheolhee-lab.github.io/layout-vlm/) renders as a broken-image icon.

## Root cause (two layers)

**1. Site-wide: GitHub Pages cannot serve Git LFS.** Per [GitHub's docs](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage), *"Git LFS cannot be used with GitHub Pages sites."* Since `1cde1ff` (*Add git-lfs support and migrate images to LFS*, #21), the legacy branch build has published the **LFS pointer file** instead of the image:

```
$ curl https://parkcheolhee-lab.github.io/img/layout-vlm/layout-vlm-0.gif
version https://git-lfs.github.com/spec/v1
oid sha256:14a322e0e3990667e5d482d4d5890ceacb8a5d97a5492171d64e10552aaf7ce7
size 1756598
```

`200 OK`, 132 bytes. The browser cannot decode it. This affects all 38 LFS-tracked `img/` directories — the whole blog.

**2. `layout-vlm` specifically: a typo disabled the fallback.** `js/utils.js` defines `handle_image_error`, which retries the image against `media.githubusercontent.com` (which *does* resolve LFS — verified: returns 1,756,598 bytes, matching the pointer's `size`). Posts wire it up as `onerror="handle_image_error(this)"`. But all six tags in `layout-vlm` had a **double equals sign**:

```html
<img ... onerror==handle_image_error(this)>
```

HTML parses this as `onerror` with the value `=handle_image_error(this)` — a JavaScript syntax error. The handler never ran, so the fallback never fired.

## Changes

- **`note/_posts/2025-08-04-layout-vlm.html`** — `onerror==` → `onerror="…"` on all 6 tags. Nothing else in the file changed.
- **`.github/workflows/pages.yml`** *(new)* — build Pages via Actions with `actions/checkout` `lfs: true`, so real binaries are published. The `onerror` fallback becomes a safety net instead of the load-bearing path.

## Verification

```
$ JEKYLL_ENV=production bundle exec jekyll build      # succeeds
$ grep -c 'onerror="handle_image_error(this)"' _site/layout-vlm/index.html
6
$ file _site/img/layout-vlm/layout-vlm-0.gif
GIF image data, version 89a, 773 x 411               # real binary, not a pointer
```

## ⚠️ Merging this alone does not finish the job

`actions/configure-pages` only *creates* a Pages site; it returns `null` on 409 and **cannot switch an existing site from `legacy` to `workflow`** ([source](https://github.com/actions/configure-pages/blob/main/src/api-client.js)). After merge, set **Settings → Pages → Build and deployment → Source → GitHub Actions**, or the `deploy` job will fail. The legacy build keeps serving the current site until then, so there is no outage window.

## Trade-off worth knowing

Each build downloads ~314 MB of LFS objects. GitHub Free includes 10 GiB/month of LFS bandwidth, and [Actions downloads count against it](https://docs.github.com/en/billing/concepts/product-billing/git-lfs) — roughly 32 builds/month. If that gets tight, cache the LFS objects or move images out of LFS entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)