### PR TITLE
Publish Pages after the latentspace bot merges

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,12 @@ name: Deploy Jekyll site to Pages
 on:
   push:
     branches: [main]
+  # Build Latent Space merges its own commit using GITHUB_TOKEN, and GitHub
+  # never fires `push` for those. Without this trigger the automated
+  # latentspace.json update would sit on main and never publish.
+  workflow_run:
+    workflows: ["Build Latent Space"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +23,10 @@ concurrency:
 
 jobs:
   build:
+    # `completed` fires on failure too; only publish a successful upstream run.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to #89. Found while monitoring that merge — both problems were invisible in the green checkmarks.

## Problem

`build-latentspace.yml` creates and merges its own PR using `secrets.GITHUB_TOKEN`. Per [GitHub's docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow):

> "if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when `push` events occur."

So `pages.yml` (`on: push`) never ran for `c5eecd0` (*Update latentspace.json [automated]*, #90). That commit is `main`, but it is not published — the live site is stale:

```
live  data/latentspace.json: 64806 B   (deployed sha 7605b14)
main  data/latentspace.json: 64800 B   (#90, never published)
```

Previously the legacy branch builder papered over this, since it deploys on any commit. That builder has now been disabled (Pages source → GitHub Actions) to stop it racing the Actions build and republishing LFS pointers. With legacy gone, nothing publishes latentspace commits at all.

## Change

Add a `workflow_run` trigger on `Build Latent Space` completion. `workflow_run` sets `GITHUB_SHA` to the *last commit on the default branch* ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)), which is exactly the bot's merge commit — so the checkout picks up the new `latentspace.json`.

`types: [completed]` also fires on failure, so the `build` job is guarded:

```yaml
if: >-
  github.event_name != 'workflow_run' ||
  github.event.workflow_run.conclusion == 'success'
```

A failed embedding run cannot publish.

## Verification

Parsed the workflow and asserted the wiring, rather than eyeballing it:

```
YAML valid. triggers: push, workflow_dispatch, workflow_run
guard: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
upstream name: "Build Latent Space"
name matches trigger exactly
```

`lfs: true` on checkout is asserted to still be set — that is the line keeping the images unbroken.

## Note

A post edit now deploys twice: once on `push`, once when `Build Latent Space` finishes. The second is the correct one and wins. `concurrency: group: pages` serializes them, so this is wasted minutes, not a race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)