### PR TITLE
Update the behavior-aware post

### DIFF
--- a/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
+++ b/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
@@ -158,7 +158,7 @@ related:
                     <li>
                         Meaningful spatial reasoning emerges when objects are considered as part of behavioral configurations; for example, <strong>chairs around a desk forming a workspace or sofas arranged around a coffee table creating a lounge area</strong>. The <strong>[E] Semantic Grouping</strong> stage identifies both <strong>intra-group spatial relations</strong> (internal arrangement within a functional unit) and <strong>inter-group spatial relations</strong> (connectivity between distinct groups).
                         <figure>
-                            <div class="viz-scene" id="s-grouping" style="height:460px" data-cam="3.691,-2.691,2.627" data-target="0.1,0.9,0.5"></div>
+                            <div class="viz-scene" id="s-grouping" style="height:460px" data-cam="3.312,-3.128,2.528" data-target="-0.279,0.463,0.401"></div>
                             <figcaption class="nofig">[E] Semantic Grouping &middot; objects that function together form a group (work / lounge / storage); solid links are intra-group relations, dashed magenta links are inter-group relations.</figcaption>
                         </figure>
                     </li>

--- a/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
+++ b/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
@@ -151,14 +151,14 @@ related:
                     <li>
                         The VLM also produces a <strong>[D] Human-Object Interaction Pattern</strong>, identifying the top five human actions associated with the object based on atomic visual actions (e.g., sit, open, pull).
                         <figure>
-                            <div class="viz-scene" id="s-interaction" style="height:420px" data-cam="5.0,-4.2,2.2" data-target="2.6,0.2,0.95"></div>
+                            <div class="viz-scene" id="s-interaction" style="height:420px" data-cam="5.969,-3.169,2.946" data-target="2.6,0.2,0.95"></div>
                             <figcaption class="nofig">[D] Human-Object Interaction Pattern &middot; the top actions the object affords &mdash; open / close (door), pull / push (drawer), touch; two-bone inverse kinematics lands each hand on the movable part.</figcaption>
                         </figure>
                     </li>
                     <li>
                         Meaningful spatial reasoning emerges when objects are considered as part of behavioral configurations; for example, <strong>chairs around a desk forming a workspace or sofas arranged around a coffee table creating a lounge area</strong>. The <strong>[E] Semantic Grouping</strong> stage identifies both <strong>intra-group spatial relations</strong> (internal arrangement within a functional unit) and <strong>inter-group spatial relations</strong> (connectivity between distinct groups).
                         <figure>
-                            <div class="viz-scene" id="s-grouping" style="height:460px" data-cam="2.66,-3.79,1.83" data-target="0.1,0.9,0.5"></div>
+                            <div class="viz-scene" id="s-grouping" style="height:460px" data-cam="3.691,-2.691,2.627" data-target="0.1,0.9,0.5"></div>
                             <figcaption class="nofig">[E] Semantic Grouping &middot; objects that function together form a group (work / lounge / storage); solid links are intra-group relations, dashed magenta links are inter-group relations.</figcaption>
                         </figure>
                     </li>

--- a/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
+++ b/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
@@ -211,8 +211,10 @@ related:
                             Spatial Constraint Taxonomy for Behavior-Aware Anthropometric Scene Generation, comparing our behavior-aware, anthropometrically grounded constraints with the geometric relations [4].
                             &middot; Notation: \(p_i, p_j\) object poses; \(w_j\) wall index; \(b_i\) object bounding box; \(d_{\min}, d_{\max}\) minimum/maximum center distance; \(\Theta\) relative angle; \(h\) height offset.
                         </figcaption>
+                        <br>
                         <figure>
-
+                            <div class="viz-scene" id="s-taxonomy" style="height:420px" data-cam="8.792,-4.842,3.549" data-target="4.222,-0.272,0.849"></div>
+                            <figcaption class="nofig">Spatial constraint taxonomy, animated &middot; each of Table 1's five losses pulls its movable object from a violating placement (high loss) into the satisfied one (loss &rarr; 0); the coloured arrow is the loss's negative gradient. Grouped by type &mdash; position (blue), orientation (amber), height (green).</figcaption>
                         </figure>
                     </li>
                     <br>

--- a/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
+++ b/note/_posts/2026-04-20-behavior-aware-anthropometric-scene-generation-for-human-usable-3d-layouts.html
@@ -39,7 +39,7 @@ related:
                 Introduction
                 <ul>
                     <li> 
-                        Physical environments fundamentally shape human movements and behavior.
+                        Physical environments fundamentally shape human movements and behavior [1].
                         In the real world, <strong>layouts are rarely static; users naturally adjust their surroundings</strong> to fit their specific body dimensions and movements.
                     </li>
                     <li>
@@ -66,7 +66,7 @@ related:
                     <li>
                         For PO and HO conditions, we instantiated
                         <strong>participant-specific anthropometric profiles</strong> from each participant's
-                        Skinned Multi-Person Linear (SMPL) model, parameterizing
+                        Skinned Multi-Person Linear (SMPL) [2] model, parameterizing
                         the constraints (e.g., passage widths, reaching envelopes, and viewing requirements) to each participant's actual body dimensions. 
                     </li>
                 </ul>
@@ -79,23 +79,23 @@ related:
                         Ergonomics literature distinguishes between
                         structural anthropometry—static body dimensions—and functional
                         anthropometry, which describes the dynamic range of motion and
-                        clearance required for tasks, emphasizing that true usability depends on accommodating the latter.
+                        clearance required for tasks, emphasizing that true usability depends on accommodating the latter [3].
                         <figure>
                             <div class="viz-scene" id="s-dims" style="height:440px" data-cam="5.3,-3.3,2.8" data-target="1.7,0,0.95"></div>
                             <figcaption class="nofig">Structural anthropometry (gray, the static body box) and functional anthropometry (green, the movement and reach envelope). The camera can be controlled with the mouse.</figcaption>
                         </figure>
                     </li>
                     <li>
-                        Our work builds
-                        upon LayoutVLM's constraint optimization framework but extends
-                        it by integrating anthropometric data directly into the constraint
-                        quantification process.
+                        Our work 
                         <mark>
-
+                            builds
+                            upon LayoutVLM [4]'s constraint optimization framework but extends
+                        it by integrating anthropometric data 
+                        </mark>
+                        directly into the constraint quantification process.
                             Rather than relying on generic distances
                             from LLM common sense, we compute person-specific operational
                             requirements based on individual body measurements and intended interactions
-                        </mark>
                         — advancing scene generation from semantically plausible to human-operational.
                     </li>
                     <!-- <li>
@@ -106,7 +106,7 @@ related:
                     <li>
                         The importance of this personalization becomes evident when considering human diversity; a 5th
                         percentile female and a 95th percentile male require substantially
-                        different operational spaces; however, <strong>
+                        different operational spaces [5]; however, <strong>
                             current anthropometric-driven design methods apply
                             uniform constraints that may be insufficient for larger individuals
                             or wastefully spacious for smaller ones.
@@ -116,7 +116,7 @@ related:
                     </li>
                     <li>
                         Although <mark>Fréchet Inception Distance and Kernel
-                        Inception Distance metrics effectively validate visual quality
+                        Inception Distance metrics [6, 7, 8] effectively validate visual quality
                         and learning performance, they fail to capture the behavioral and
                         operational aspects</mark> that determine the actual usability.
                     </li>
@@ -149,7 +149,7 @@ related:
                         </figure>
                     </li>
                     <li>
-                        The VLM also produces a <strong>[D] Human-Object Interaction Pattern</strong>, identifying the top five human actions associated with the object based on atomic visual actions (e.g., sit, open, pull).
+                        The VLM also produces a <strong>[D] Human-Object Interaction Pattern</strong>, identifying the top five human actions associated with the object based on atomic visual actions (e.g., sit, open, pull) [9].
                         <figure>
                             <div class="viz-scene" id="s-interaction" style="height:420px" data-cam="5.969,-3.169,2.946" data-target="2.6,0.2,0.95"></div>
                             <figcaption class="nofig">[D] Human-Object Interaction Pattern &middot; the top actions the object affords &mdash; open / close (door), pull / push (drawer), touch; two-bone inverse kinematics lands each hand on the movable part.</figcaption>
@@ -163,7 +163,62 @@ related:
                         </figure>
                     </li>
                     <li>
-                        
+                        The <strong>[F-G] stages infer anthropometrically grounded constraint representations</strong> from natural-language spatial relations. 
+                        They convert these relations 
+                        into executable, differentiable constraints
+                        required for spatial optimization. 
+                        <mark>
+                            Our framework infers constraint specifications by explicitly referencing behavioral
+                            semantics and anthropometric rationale.
+                        </mark>
+                    </li>
+                    <!-- <li>
+                        Prior work defines constraints
+                        in geometric terms, focusing on the distances and angles between
+                        assets, independent of how people interact with them.
+                        By contrast,
+                        our formulation explicitly encodes how people need to reach, access,
+                        and operate furniture.
+                    </li> -->
+                    <li>
+                        The taxonomy organizes natural-language
+                        relations into learnable constraint types (positional, orientational,
+                        and height-based) such as chair against wall, table aligned with sofa,
+                        or lamp on top of desk.
+                        <div class="latex-container">
+                        \[
+                        \begin{array}{llll}
+                        \hline
+                        \textbf{Constraint Type} & \textbf{Constraint Name} & \textbf{Method} & \textbf{Description} \\
+                        \hline
+                        \text{Position-based} & L_{\text{distance}}(p_i, p_j, d_{\min}, d_{\max}) & \text{LayoutVLM} & \text{Distance between the two assets should fall within the range } [d_{\min}, d_{\max}]. \\
+                         & & \text{Ours} & \text{Distance between two objects to } [d_{\min}, d_{\max}]\text{, where bounds are inferred from reach and clearance requirements based on anthropometric data.} \\
+                         & L_{\text{against wall}}(p_i, w_j, b_i) & \text{LayoutVLM} & \text{Place an asset against wall } w_j. \\
+                         & & \text{Ours} & \text{Places the object against a specific wall while considering accessibility and clearance requirements for nearby interactions.} \\
+                        \hline
+                        \text{Orientation-based} & L_{\text{align with}}(p_i, p_j, \Theta) & \text{LayoutVLM} & \text{Align two assets at a specified angle } \Theta. \\
+                         & & \text{Ours} & \text{Aligns the rotations of two objects; the angle parameter } \Theta \text{ reflects task-oriented alignment (e.g., parallel or perpendicular configurations for joint use).} \\
+                         & L_{\text{point towards}}(p_i, p_j, \Theta) & \text{LayoutVLM} & \text{Orient one asset to face another with an offset angle } \Theta. \\
+                         & & \text{Ours} & \text{Adjusts orientation so that an object's front faces the target, with } \Theta \text{ encoding preferred viewing or interaction directions (e.g., facing a desk, or seating area).} \\
+                        \hline
+                        \text{Height-based} & L_{\text{on top of}}(p_i, p_j, h) & \text{LayoutVLM} & \text{Position one asset on top of another.} \\
+                         & & \text{Ours} & \text{Defines a vertical stacking relationship for placing smaller objects on surfaces while keeping sufficient interaction area.} \\
+                        \hline
+                        \end{array}
+                        \]
+                        </div>
+                        <figcaption class="nofig">
+                            Spatial Constraint Taxonomy for Behavior-Aware Anthropometric Scene Generation, comparing our behavior-aware, anthropometrically grounded constraints with the geometric relations [4].
+                            &middot; Notation: \(p_i, p_j\) object poses; \(w_j\) wall index; \(b_i\) object bounding box; \(d_{\min}, d_{\max}\) minimum/maximum center distance; \(\Theta\) relative angle; \(h\) height offset.
+                        </figcaption>
+                        <figure>
+
+                        </figure>
+                    </li>
+                    <br>
+                    <li>
+                        Among these, distance constraint requires additional clarification, 
+                        because it directly governs human accessibility and functional clearance. 
                     </li>
                 </ul>
             </li>
@@ -183,6 +238,28 @@ related:
                     <li>
 
                     </li>
+                </ul>
+            </li>
+            <li>
+                Conclusion
+                <ul>
+                    <li>
+                        
+                    </li>
+                </ul>
+            </li>
+            <li>
+                References
+                <ul>
+                    <li>[1] Weizhou Luo, Zhongyuan Yu, Rufat Rzayev, Marc Satkowski, Stefan Gumhold, Matthew McGinity, and Raimund Dachselt. 2023. <a href="https://doi.org/10.1145/3544548.3580715" target="_blank" rel="noopener noreferrer">Pearl: Physical Environment Based Augmented Reality Lenses for In-Situ Human Movement Analysis</a>. In Proceedings of the 2023 CHI Conference on Human Factors in Computing Systems (CHI '23), 1&ndash;15.</li>
+                    <li>[2] Matthew Loper, Naureen Mahmood, Javier Romero, Gerard Pons-Moll, and Michael J. Black. 2015. <a href="https://doi.org/10.1145/2816795.2818013" target="_blank" rel="noopener noreferrer">SMPL: A Skinned Multi-Person Linear Model</a>. ACM Transactions on Graphics (Proc. SIGGRAPH Asia) 34, 6 (2015), 248:1&ndash;248:16.</li>
+                    <li>[3] Carlos Viviani, Pedro M. Arezes, Sara Bragan&ccedil;a, Johan Molenbroek, Iman Dianat, and Hector I. Castellucci. 2018. <a href="https://doi.org/10.1016/j.ergon.2018.01.012" target="_blank" rel="noopener noreferrer">Accuracy, Precision and Reliability in Anthropometric Surveys for Ergonomics Purposes in Adult Working Populations: A Literature Review</a>. International Journal of Industrial Ergonomics 65 (2018), 1&ndash;16.</li>
+                    <li>[4] Fan-Yun Sun, Weiyu Liu, Siyi Gu, Dylan Lim, Goutam Bhat, Federico Tombari, Manling Li, Nick Haber, and Jiajun Wu. 2025. <a href="https://arxiv.org/abs/2412.02193" target="_blank" rel="noopener noreferrer">LayoutVLM: Differentiable Optimization of 3D Layout via Vision-Language Models</a>. In Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR), 29469&ndash;29478.</li>
+                    <li>[5] Julius Panero and Martin Zelnik. 1979. <a href="https://openlibrary.org/works/OL6565998W" target="_blank" rel="noopener noreferrer">Human Dimension and Interior Space: A Source Book of Design Reference Standards</a>. Watson-Guptill, New York.</li>
+                    <li>[6] Chenguo Lin and Yadong Mu. 2024. <a href="https://arxiv.org/abs/2402.04717" target="_blank" rel="noopener noreferrer">InstructScene: Instruction-Driven 3D Indoor Scene Synthesis with Semantic Graph Prior</a>. arXiv:2402.04717.</li>
+                    <li>[7] Despoina Paschalidou, Amlan Kar, Maria Shugrina, Karsten Kreis, Andreas Geiger, and Sanja Fidler. 2021. <a href="https://arxiv.org/abs/2110.03675" target="_blank" rel="noopener noreferrer">ATISS: Autoregressive Transformers for Indoor Scene Synthesis</a>. In Advances in Neural Information Processing Systems (NeurIPS) 34 (2021), 12013&ndash;12026.</li>
+                    <li>[8] Jiapeng Tang, Yinyu Nie, Lev Markhasin, Angela Dai, Justus Thies, and Matthias Nie&szlig;ner. 2024. <a href="https://arxiv.org/abs/2303.14207" target="_blank" rel="noopener noreferrer">DiffuScene: Denoising Diffusion Models for Generative Indoor Scene Synthesis</a>. In Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR), 20507&ndash;20518.</li>
+                    <li>[9] Chunhui Gu, Chen Sun, David A. Ross, Carl Vondrick, Caroline Pantofaru, Yeqing Li, Sudheendra Vijayanarasimhan, George Toderici, Susanna Ricco, Rahul Sukthankar, Cordelia Schmid, and Jitendra Malik. 2018. <a href="https://arxiv.org/abs/1705.08421" target="_blank" rel="noopener noreferrer">AVA: A Video Dataset of Spatio-temporally Localized Atomic Visual Actions</a>. In Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 6047&ndash;6056.</li>
                 </ul>
             </li>
         </ol>

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -154,6 +154,24 @@ function makeChair(seatH) {
   }
   return g;
 }
+// two-seat sofa, faces +Y (backrest at -Y) — shared by the semantic-grouping and taxonomy figures.
+// optional uniform scale s (default 1) enlarges the whole sofa without touching call sites that omit it.
+function makeSofa(s) {
+  s = s || 1;
+  const g = new THREE.Group(), mat = new THREE.MeshStandardMaterial({ color: 0x8a8f98, roughness: .75 });
+  const add = (w, d, h, x, y, z) => { const m = new THREE.Mesh(new THREE.BoxGeometry(w * s, d * s, h * s), mat); m.position.set(x * s, y * s, z * s); g.add(m); };
+  add(0.92, 0.52, 0.22, 0, 0, 0.14); add(0.86, 0.48, 0.12, 0, 0.02, 0.31); add(0.92, 0.14, 0.36, 0, -0.19, 0.42);
+  add(0.1, 0.52, 0.34, -0.41, 0, 0.36); add(0.1, 0.52, 0.34, 0.41, 0, 0.36);
+  return g;
+}
+// large flat-screen TV on a low media console; screen faces -Y (toward the viewer / sofa)
+function makeTV() {
+  const g = new THREE.Group();
+  const box = new THREE.Mesh(new THREE.BoxGeometry(1.05, 0.34, 0.3), MAT.wood()); box.position.set(0, 0, 0.15); g.add(box);
+  const bezel = new THREE.Mesh(new THREE.BoxGeometry(1.08, 0.05, 0.66), new THREE.MeshStandardMaterial({ color: 0x23272e, roughness: .35 })); bezel.position.set(0, -0.02, 0.7); g.add(bezel);
+  const screen = new THREE.Mesh(new THREE.BoxGeometry(0.98, 0.01, 0.56), new THREE.MeshStandardMaterial({ color: 0x9fb4e8, roughness: .3 })); screen.position.set(0, -0.045, 0.7); g.add(screen);
+  return g;
+}
 
 // ---------- wooden mannequin (faces +Y) ----------
 function poseJoints(pose) {
@@ -612,13 +630,6 @@ function buildStageE(scene) {
   const solidEdge = (a, b, color, op) => new THREE.Line(new THREE.BufferGeometry().setFromPoints([V(a[0], a[1], a[2]), V(b[0], b[1], b[2])]), new THREE.LineBasicMaterial({ color, transparent: true, opacity: op }));
   function dashEdge(a, b, color) { const l = new THREE.Line(new THREE.BufferGeometry().setFromPoints([V(a[0], a[1], a[2]), V(b[0], b[1], b[2])]), new THREE.LineDashedMaterial({ color, dashSize: 0.09, gapSize: 0.06 })); l.computeLineDistances(); return l; }
   const mid = (a, b) => [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
-  function makeSofa() {
-    const g = new THREE.Group(), mat = new THREE.MeshStandardMaterial({ color: 0x8a8f98, roughness: .75 });
-    const add = (w, d, h, x, y, z) => { const m = new THREE.Mesh(new THREE.BoxGeometry(w, d, h), mat); m.position.set(x, y, z); g.add(m); };
-    add(0.92, 0.52, 0.22, 0, 0, 0.14); add(0.86, 0.48, 0.12, 0, 0.02, 0.31); add(0.92, 0.14, 0.36, 0, -0.19, 0.42);
-    add(0.1, 0.52, 0.34, -0.41, 0, 0.36); add(0.1, 0.52, 0.34, 0.41, 0, 0.36);
-    return g;
-  }
   floorGrid(scene, 14);
   const groups = [
     { name: 'individual work area', cls: 'fb', color: 0x3a5cc0, make() {
@@ -662,6 +673,114 @@ function buildStageE(scene) {
   scene.add(label('inter-group', 'm', mm[0], mm[1], mm[2] + 0.04));
 }
 
+// ---------- Method §3.2 · Spatial Constraint Taxonomy (the figure after Table 1) ----------
+// Animates each of Table 1's five losses. Reuses the furniture + dim / label helpers. Annotation
+// ink is coloured by TYPE — position=blue, orientation=amber, height=green — matching fb / fa / gr.
+const TAXCOL = { pos: 0x3a5cc0, ori: 0xa8752a, ht: 0x2fa35a };
+
+// cheap updatable arrow (three lines: shaft + two head strokes); set(from,to) rewrites the buffers
+function flowArrow(color) {
+  const m = new THREE.LineBasicMaterial({ color });
+  const shaft = new THREE.Line(new THREE.BufferGeometry(), m), h1 = new THREE.Line(new THREE.BufferGeometry(), m), h2 = new THREE.Line(new THREE.BufferGeometry(), m);
+  const g = new THREE.Group(); g.add(shaft); g.add(h1); g.add(h2);
+  g.userData.set = (from, to, head) => {
+    head = head == null ? 0.075 : head;
+    const A = new THREE.Vector3(from[0], from[1], from[2]), B = new THREE.Vector3(to[0], to[1], to[2]);
+    const d = new THREE.Vector3().subVectors(B, A), len = d.length();
+    if (len < 2e-3) { g.visible = false; return; } g.visible = true; d.normalize();
+    const ref = Math.abs(d.z) > 0.85 ? new THREE.Vector3(1, 0, 0) : new THREE.Vector3(0, 0, 1);
+    const perp = new THREE.Vector3().crossVectors(d, ref).normalize().multiplyScalar(head * 0.6), back = d.clone().multiplyScalar(-head);
+    shaft.geometry.setFromPoints([A, B]);
+    h1.geometry.setFromPoints([B, B.clone().add(back).add(perp)]);
+    h2.geometry.setFromPoints([B, B.clone().add(back).sub(perp)]);
+  };
+  return g;
+}
+// a translucent floor "facing cone" (like a flashlight beam) opening +Y in local — shows which way an object
+// looks; add as a child so it sweeps as the object rotates.
+function facingCone(color) {
+  const sh = new THREE.Shape(), r = 0.55, ha = 0.42, n = 14; sh.moveTo(0, 0);
+  for (let i = 0; i <= n; i++) { const a = Math.PI / 2 - ha + 2 * ha * i / n; sh.lineTo(r * Math.cos(a), r * Math.sin(a)); }
+  sh.closePath();
+  return new THREE.Mesh(new THREE.ShapeGeometry(sh), new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.2, side: THREE.DoubleSide, depthWrite: false }));
+}
+// each constraint animates VIOLATION -> SATISFIED; a force arrow (the −gradient of the loss)
+// pulls the movable object into the relation, which reads as loss -> 0.
+// Grouped by the three types, colour-coded blue / amber / green. Green marks the satisfied target.
+function buildTaxLoss(scene) {
+  floorGrid(scene, 18);
+  const lerp = (a, b, s) => a + (b - a) * s, upd = [];
+  (() => {  // distance (blue): BOTH objects adjust until their CENTRE-TO-CENTRE distance enters [d_min,d_max]
+    const c = TAXCOL.pos, mx = 0.0, dMin = 0.7, dMax = 1.0, yAx = -0.62, zAx = 0.02, dFar = 1.7, dSat = 0.85;
+    const desk = makeDesk(1.05, 0.58, 0.73); desk.rotation.z = Math.PI / 2; scene.add(desk);  // full-height desk (0.73) so the chair fits under; long edge toward the chair
+    const chair = makeChair(0.46); chair.rotation.z = -Math.PI / 2; scene.add(chair);          // seat faces +X, toward the desk
+    // fixed green valid-distance zones: where each centre's projection onto the dim axis should land (symmetric)
+    const bandMat = new THREE.MeshBasicMaterial({ color: 0x2fa35a, transparent: true, opacity: 0.22, side: THREE.DoubleSide, depthWrite: false });
+    [-1, 1].forEach(sgn => { const b = new THREE.Mesh(new THREE.BoxGeometry((dMax - dMin) / 2, 0.14, 0.008), bandMat); b.position.set(mx + sgn * (dMin + dMax) / 4, yAx, zAx); scene.add(b); });
+    // live centre-to-centre dimension below the objects (shaft + end ticks + extension lines); turns green in range
+    const dmat = new THREE.LineBasicMaterial({ color: 0x8a9097 });
+    const shaft = new THREE.Line(new THREE.BufferGeometry(), dmat), tL = new THREE.Line(new THREE.BufferGeometry(), dmat), tR = new THREE.Line(new THREE.BufferGeometry(), dmat), eL = new THREE.Line(new THREE.BufferGeometry(), dmat), eR = new THREE.Line(new THREE.BufferGeometry(), dmat);
+    [shaft, tL, tR, eL, eR].forEach(o => scene.add(o));
+    scene.add(label('[d_min, d_max]', 'g', mx, yAx - 0.18, 0.05));
+    const aL = flowArrow(c), aR = flowArrow(c); scene.add(aL); scene.add(aR);
+    scene.add(label('distance', 'fb', mx, 0.02, 1.18));
+    const P = (x, y, z) => new THREE.Vector3(x, y, z);
+    upd.push(s => {
+      const d = lerp(dFar, dSat, s), xL = mx - d / 2, xR = mx + d / 2;
+      chair.position.set(xL, 0, 0); desk.position.set(xR, 0, 0);
+      shaft.geometry.setFromPoints([P(xL, yAx, zAx), P(xR, yAx, zAx)]);
+      tL.geometry.setFromPoints([P(xL, yAx - 0.05, zAx), P(xL, yAx + 0.05, zAx)]);
+      tR.geometry.setFromPoints([P(xR, yAx - 0.05, zAx), P(xR, yAx + 0.05, zAx)]);
+      eL.geometry.setFromPoints([P(xL, -0.02, 0.02), P(xL, yAx, zAx)]);
+      eR.geometry.setFromPoints([P(xR, -0.02, 0.02), P(xR, yAx, zAx)]);
+      dmat.color.setHex(d >= dMin && d <= dMax ? 0x2fa35a : 0x8a9097);
+      const f = (1 - s) * 0.4 + 0.02;
+      aL.userData.set([xL + 0.28, 0, 0.46], [xL + 0.28 + f, 0, 0.46]);
+      aR.userData.set([xR - 0.28, 0, 0.46], [xR - 0.28 - f, 0, 0.46]);
+    });
+  })();
+  (() => {  // against wall (blue): cabinet gap -> flush
+    const c = TAXCOL.pos, bx = 2.0;
+    const wall = boxEdges(1.35, 0.06, 1.3, 0x9aa0a6, 0.10); wall.position.set(bx, 0.55, 0.65); scene.add(wall);
+    const cab = makeStorageCabinet(0.8, 0.46, 1.15); scene.add(cab);
+    const arr = flowArrow(c); scene.add(arr);
+    scene.add(label('against wall', 'fb', bx, 0.0, 1.5));
+    upd.push(s => { const y = lerp(-0.35, 0.29, s); cab.position.set(bx, y, 0); arr.userData.set([bx, y + 0.26, 0.6], [bx, y + 0.26 + (1 - s) * 0.42 + 0.02, 0.6]); });
+  })();
+  (() => {  // align with (amber): sofa + coffee table BOTH rotate until the table's long edge is parallel to the sofa's front
+    const c = TAXCOL.ori, bx = 4.3;                                                     // (a usable lounge: table squared up in front of the seat) — symmetric, both move
+    const sofa = makeSofa(1.2); sofa.position.set(bx, -0.35, 0); scene.add(sofa);        // sofa faces +Y
+    const coneS = facingCone(c); coneS.position.set(0, 0.1, 0.02); sofa.add(coneS);
+    const table = makeDesk(0.95, 0.5, 0.4); table.position.set(bx, 0.55, 0); scene.add(table);   // coffee table IN FRONT of the sofa
+    const coneT = facingCone(c); coneT.position.set(0, 0.05, 0.02); table.add(coneT);
+    scene.add(label('parallel', 'g', bx + 0.62, 0.55, 0.35));
+    scene.add(label('align with', 'fa', bx, -0.5, 1.35));
+    upd.push(s => { sofa.rotation.z = lerp(0.5, 0, s); table.rotation.z = lerp(-0.75, 0, s); });   // BOTH rotate until parallel
+  })();
+  (() => {  // point towards (amber): the sofa turns to face the TV HEAD-ON (couch aimed straight at the screen) — one object rotates
+    const c = TAXCOL.ori, bx = 6.5;
+    const tv = makeTV(); tv.position.set(bx, 0.85, 0); scene.add(tv);                   // TV directly in front (+Y), screen faces -Y
+    const sofa = makeSofa(1.2); sofa.position.set(bx, -0.65, 0); scene.add(sofa);        // sofa on the SAME axis, straight in front of the TV
+    const cone = facingCone(c); cone.position.set(0, 0.1, 0.02); sofa.add(cone);
+    const ray = flowArrow(0x8bbf86); scene.add(ray); ray.userData.set([bx, -0.18, 0.42], [bx, 0.55, 0.42]);   // straight +Y toward the TV
+    scene.add(label('point towards', 'fa', bx, -0.2, 1.5));
+    upd.push(s => { sofa.rotation.z = lerp(-1.7, 0, s); });                             // satisfied: faces +Y, straight at the TV
+  })();
+  (() => {  // on top of (green): box drops onto the surface at height h
+    const c = TAXCOL.ht, bx = 8.5;
+    const chest = makeChest(0.72, 0.46, 0.82); chest.position.set(bx, 0, 0); scene.add(chest);
+    const box = new THREE.Mesh(new THREE.BoxGeometry(0.26, 0.26, 0.24), new THREE.MeshStandardMaterial({ color: 0xb86b5e, roughness: .7 })); scene.add(box);
+    scene.add(dimExt([bx, 0, 0], [bx, 0, 0.82], [0.5, 0, 0], [0.04, 0, 0], 'h', 'g', c, [0.16, 0, 0]));   // h on the +X side (opposite the neighbour)
+    const arr = flowArrow(c); scene.add(arr);
+    scene.add(label('on top of', 'gr', bx, 0, 1.62));
+    upd.push(s => { const z = lerp(1.4, 0.95, s), x = lerp(bx - 0.5, bx, s); box.position.set(x, 0, z); arr.userData.set([x, 0, z - 0.15], [x, 0, z - 0.15 - (1 - s) * 0.32 - 0.02]); });   // box drops from -X so it clears the h dimension
+  })();
+  scene.add(label('Position-based', 'fb', 0.85, 0.1, 1.95));
+  scene.add(label('Orientation-based', 'fa', 4.5, 0.1, 1.95));
+  scene.add(label('Height-based', 'gr', 8.5, 0.1, 2.15));
+  scene.userData.tick = (ms) => { const s = 0.5 - 0.5 * Math.cos(ms / 1000 * 0.9); upd.forEach(f => f(s)); };
+}
+
 const elConflict = document.getElementById('s-conflict');
 if (elConflict) makeScene(elConflict, buildConflict);
 const elDims = document.getElementById('s-dims');
@@ -670,3 +789,4 @@ const elB = document.getElementById('s-preproc'); if (elB) makeScene(elB, buildS
 const elC = document.getElementById('s-funcdesc'); if (elC) makeScene(elC, buildStageC);
 const elD = document.getElementById('s-interaction'); if (elD) makeScene(elD, buildStageD);
 const elE = document.getElementById('s-grouping'); if (elE) makeScene(elE, buildStageE);
+const elTaxonomy = document.getElementById('s-taxonomy'); if (elTaxonomy) makeScene(elTaxonomy, buildTaxLoss);

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -536,7 +536,11 @@ function buildStageC(scene) {
   const swingArc = new THREE.Line(new THREE.BufferGeometry().setFromPoints(arcPts), new THREE.LineDashedMaterial({ color: 0x9c4646, dashSize: 0.03, gapSize: 0.02 })); swingArc.computeLineDistances(); scene.add(swingArc);
   scene.add(label('sliding door', 'f', colW / 2, -d / 2 - 0.05, h + 0.16));
   scene.add(label('slides along X', 'g', w / 2 + 0.24, -d / 2, h - 0.05));
-  scene.add(label('hinged door (swings open)', 'm', -0.3, -d / 2 - 0.5, h / 4 - 0.02));
+  // Break the line: this label anchors outside the asset's silhouette (at the swung-open door), and
+  // frame() fits the silhouette, so on a narrow card its one-line box ran past the left edge.
+  // Lift it too — two lines are taller, and only 0.075 in z separated it from the label below, which
+  // projects to ~6px once a mobile card shrinks the world scale while the boxes stay a fixed px size.
+  scene.add(label('hinged door<br>(swings open)', 'm', -0.3, -d / 2 - 0.5, h / 4 + 0.10));
   scene.add(label('keep front clear for access', 'g', 0.12, -d / 2 - 0.56, 0.08));
   scene.userData.tick = (ms) => {
     const t = ms / 1000;

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -492,7 +492,7 @@ function buildStageB(scene, THREE, renderer) {
     return { P, T, at };
   }
   // the capture rig draws as one object: the box and the links from it to its view plane share this ink
-  const RIG = { color: 0x9ab0e8, transparent: true, opacity: 0.6 };
+  const RIG = { color: 0x9ab0e8, transparent: true, opacity: 0.8 };
   function orthoCamMarker(camPos, target, halfW, halfH, color) {
     const g = new THREE.Group();
     const { P, T, at } = viewRect(camPos, target);

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -491,18 +491,20 @@ function buildStageB(scene, THREE, renderer) {
       .add(right.clone().multiplyScalar(s[0] * hw)).add(up.clone().multiplyScalar(s[1] * hh)));
     return { P, T, at };
   }
+  // the capture rig draws as one object: the box and the links from it to its view plane share this ink
+  const RIG = { color: 0x9ab0e8, transparent: true, opacity: 0.6 };
   function orthoCamMarker(camPos, target, halfW, halfH, color) {
     const g = new THREE.Group();
     const { P, T, at } = viewRect(camPos, target);
     const near = at(P, halfW, halfH), far = at(T, halfW, halfH);
-    const m = new THREE.LineBasicMaterial({ color: 0x9ab0e8, transparent: true, opacity: 0.6 });
+    const m = new THREE.LineBasicMaterial(RIG);
     for (let i = 0; i < 4; i++) g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([near[i], far[i]]), m));
     g.add(new THREE.LineLoop(new THREE.BufferGeometry().setFromPoints(near), m));
     g.add(new THREE.LineLoop(new THREE.BufferGeometry().setFromPoints(far), m));
     g.add(makeCamera(camPos, target, color));
     return g;
   }
-  function dashLink(a, b) { const l = new THREE.Line(new THREE.BufferGeometry().setFromPoints([a, b]), new THREE.LineDashedMaterial({ color: 0x6a6aa8, dashSize: 0.06, gapSize: 0.045 })); l.computeLineDistances(); return l; }
+  function dashLink(a, b) { const l = new THREE.Line(new THREE.BufferGeometry().setFromPoints([a, b]), new THREE.LineDashedMaterial({ ...RIG, dashSize: 0.06, gapSize: 0.045 })); l.computeLineDistances(); return l; }
   const views = [{ deg: '0°', dir: [0, -1], front: true }, { deg: '90°', dir: [1, 0], front: false }, { deg: '180°', dir: [0, 1], front: true }, { deg: '270°', dir: [-1, 0], front: false }];
   floorGrid(scene, 10);
   const a = makeAsset(); scene.add(a.group);

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -479,14 +479,22 @@ function buildStageB(scene, THREE, renderer) {
     g.quaternion.setFromUnitVectors(V(0, 1, 0), dir); g.position.set(camPos[0], camPos[1], camPos[2]);
     return g;
   }
-  function orthoCamMarker(camPos, target, halfW, halfH, color) {
-    const g = new THREE.Group();
+  // A view's camera basis. `at(centre, halfW, halfH)` returns that rect's 4 world corners, always in the
+  // same winding, so two rects on the same view axis can be linked corner-to-corner without crossing.
+  // The billboard's own lookAt basis works out to this same (right, up), so plane corners share it.
+  function viewRect(camPos, target) {
     const P = V(camPos[0], camPos[1], camPos[2]), T = V(target[0], target[1], target[2]);
-    const dir = T.clone().sub(P); dir.normalize();
+    const dir = T.clone().sub(P).normalize();
     const right = new THREE.Vector3().crossVectors(dir, V(0, 0, 1)).normalize();
     const up = new THREE.Vector3().crossVectors(right, dir).normalize();
-    const rectAt = ctr => [[1, 1], [-1, 1], [-1, -1], [1, -1]].map(s => ctr.clone().add(right.clone().multiplyScalar(s[0] * halfW)).add(up.clone().multiplyScalar(s[1] * halfH)));
-    const near = rectAt(P), far = rectAt(T);
+    const at = (ctr, hw, hh) => [[1, 1], [-1, 1], [-1, -1], [1, -1]].map(s => ctr.clone()
+      .add(right.clone().multiplyScalar(s[0] * hw)).add(up.clone().multiplyScalar(s[1] * hh)));
+    return { P, T, at };
+  }
+  function orthoCamMarker(camPos, target, halfW, halfH, color) {
+    const g = new THREE.Group();
+    const { P, T, at } = viewRect(camPos, target);
+    const near = at(P, halfW, halfH), far = at(T, halfW, halfH);
     const m = new THREE.LineBasicMaterial({ color: 0x9ab0e8, transparent: true, opacity: 0.6 });
     for (let i = 0; i < 4; i++) g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([near[i], far[i]]), m));
     g.add(new THREE.LineLoop(new THREE.BufferGeometry().setFromPoints(near), m));
@@ -494,7 +502,7 @@ function buildStageB(scene, THREE, renderer) {
     g.add(makeCamera(camPos, target, color));
     return g;
   }
-  function dashLink(a, b) { const l = new THREE.Line(new THREE.BufferGeometry().setFromPoints([V(a[0], a[1], a[2]), V(b[0], b[1], b[2])]), new THREE.LineDashedMaterial({ color: 0x6a6aa8, dashSize: 0.06, gapSize: 0.045 })); l.computeLineDistances(); return l; }
+  function dashLink(a, b) { const l = new THREE.Line(new THREE.BufferGeometry().setFromPoints([a, b]), new THREE.LineDashedMaterial({ color: 0x6a6aa8, dashSize: 0.06, gapSize: 0.045 })); l.computeLineDistances(); return l; }
   const views = [{ deg: '0°', dir: [0, -1], front: true }, { deg: '90°', dir: [1, 0], front: false }, { deg: '180°', dir: [0, 1], front: true }, { deg: '270°', dir: [-1, 0], front: false }];
   floorGrid(scene, 10);
   const a = makeAsset(); scene.add(a.group);
@@ -510,10 +518,17 @@ function buildStageB(scene, THREE, renderer) {
     const pw = 2 * halfW * ds, ph = 2 * halfH * ds;
     const camP = [v.dir[0] * Rc, v.dir[1] * Rc, camZ], pos = [v.dir[0] * Ro, v.dir[1] * Ro, billZ];
     const faceDist = v.front ? 0.2 : 0.45, boxHW = v.front ? 0.46 : 0.21, boxHH = 0.36;
-    scene.add(orthoCamMarker(camP, [v.dir[0] * faceDist, v.dir[1] * faceDist, camZ], boxHW, boxHH, 0x3a5cc0));
+    const faceTarget = [v.dir[0] * faceDist, v.dir[1] * faceDist, camZ];
+    scene.add(orthoCamMarker(camP, faceTarget, boxHW, boxHH, 0x3a5cc0));
     scene.add(billboard(tex, pos, pw, ph, [pos[0] + v.dir[0], pos[1] + v.dir[1], pos[2]]));
     scene.add(label(v.deg, '', pos[0], pos[1], pos[2] + ph / 2 + 0.18));
-    scene.add(dashLink(camP, [v.dir[0] * (Ro - pw * 0.5), v.dir[1] * (Ro - pw * 0.5), billZ]));
+    // Link the capture box's outer face to the view plane corner-to-corner. That face is what the
+    // orthographic camera captures, and the plane is that capture — a single centre line read as if
+    // the camera sampled one point.
+    const { P, at } = viewRect(camP, faceTarget);
+    const boxFace = at(P, boxHW, boxHH);
+    const planeFace = at(V(pos[0], pos[1], pos[2]), (pw + 0.05) / 2, (ph + 0.05) / 2);   // the billboard's drawn border
+    for (let i = 0; i < 4; i++) scene.add(dashLink(boxFace[i], planeFace[i]));
   });
   renderer.setClearColor(oldColor, oldAlpha);
 }

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -278,7 +278,7 @@ function makeScene(container, build) {
   const scene = new THREE.Scene();
   const cp = (container.dataset.cam || '2.5,-2.6,1.9').split(',').map(Number);
   const tg = (container.dataset.target || '0,0,0.6').split(',').map(Number);
-  // orthographic, framed to match the old 42° perspective: half-height = dist(cam,target)·tan(fov/2)
+  // seed half-height only; frame() replaces it with a content fit once the scene is built
   const halfH = Math.hypot(cp[0]-tg[0], cp[1]-tg[1], cp[2]-tg[2]) * Math.tan(21 * Math.PI/180);
   const cam = new THREE.OrthographicCamera(-halfH*W/H, halfH*W/H, halfH, -halfH, 0.05, 100); cam.up.set(0, 0, 1);
   cam.position.set(cp[0], cp[1], cp[2]);
@@ -297,28 +297,50 @@ function makeScene(container, build) {
   ctr.minZoom = 0.7; ctr.maxZoom = 2.5; // ortho zoom clamps (minDistance/maxDistance are no-ops for OrthographicCamera)
   ctr.target.set(tg[0], tg[1], tg[2]);
   build(scene, THREE, renderer);   // renderer passed so a build can render-to-texture (multi-view capture)
-  // responsive framing: keep the tuned vertical extent (halfH) on wide screens, but on narrow (mobile)
-  // viewports zoom out so the full content WIDTH still fits — otherwise wide figures get clipped left/right.
+  // Content-fit framing. The camera is orthographic, so cam.top (hH) IS the zoom — dist(cam,target)
+  // only sets the view direction. Fit hH to the silhouette the camera actually sees: project every
+  // vertex onto the camera's right/up axes. A bounding-sphere estimate cannot do this, because a
+  // sphere's radius is the half-DIAGONAL: stage B's flat view planes and the long storage run
+  // measured ~15% wider than they draw, and the resulting margin was visible as dead space.
   const target = new THREE.Vector3(tg[0], tg[1], tg[2]);
   const fwd = new THREE.Vector3().subVectors(target, cam.position).normalize();
   const right = new THREE.Vector3().crossVectors(fwd, new THREE.Vector3(0, 0, 1)).normalize();
-  // content half-width along the camera's RIGHT axis. Project each mesh's world bounding sphere
-  // (center·right ± radius) instead of an axis-aligned Box3's 8 corners: for a diagonal camera over a
-  // plus-shaped layout (stage B's 4 view planes) the empty AABB corners project onto the 45° right-axis
-  // at ~√2× the true width, which over-zoomed wide figures — worst on mobile, where width binds the fit.
+  const up = new THREE.Vector3().crossVectors(right, fwd).normalize();
   scene.updateMatrixWorld(true);
-  const tR = target.dot(right), sph = new THREE.Sphere();
-  let halfW = halfH;
+  const tR = target.dot(right), tU = target.dot(up), v = new THREE.Vector3();
+  let cW = 0, cH = 0;   // content half-extents, measured from the target (= the frame centre)
   scene.traverse(o => {
-    if (o.userData && o.userData.isFloor || !o.geometry) return;   // skip floor grid and label-only nodes
-    if (!o.geometry.boundingSphere) o.geometry.computeBoundingSphere();
-    sph.copy(o.geometry.boundingSphere).applyMatrix4(o.matrixWorld);
-    halfW = Math.max(halfW, Math.abs(sph.center.dot(right) - tR) + sph.radius);
+    if (o.userData.isFloor || !o.geometry) return;   // the floor grid is backdrop, not content
+    const pos = o.geometry.attributes.position; if (!pos) return;
+    for (let i = 0; i < pos.count; i++) {
+      v.fromBufferAttribute(pos, i).applyMatrix4(o.matrixWorld);
+      cW = Math.max(cW, Math.abs(v.dot(right) - tR));
+      cH = Math.max(cH, Math.abs(v.dot(up) - tU));
+    }
   });
-  const FIT = 1.22;   // margin so edge labels (CSS2D, wider than their anchor point) aren't clipped
+  // Labels are fixed-size DOM boxes, so their footprint shrinks as the camera zooms out and cannot be
+  // expressed in world units. Render once to attach them, then solve hH per label so its box clears the
+  // container edge. This replaces the old blanket 1.22 fit factor, which padded every scene for the
+  // worst-case label whether or not that scene had one near an edge.
+  lr.render(scene, cam);
+  const labels = [];
+  scene.traverse(o => {
+    if (!o.isCSS2DObject) return;
+    const wp = o.getWorldPosition(new THREE.Vector3());
+    labels.push({ r: Math.abs(wp.dot(right) - tR), u: Math.abs(wp.dot(up) - tU),
+                  bx: o.element.offsetWidth / 2, by: o.element.offsetHeight / 2 });
+  });
+  const MARGIN = 1.04;   // breathing room so the silhouette never touches the card edge
+  const EDGE = 6;        // px kept clear at the container edge
   function frame() {
     const w = container.clientWidth, h = container.clientHeight; if (!w || !h) return;
-    const aspect = w / h, hH = Math.max(halfH, halfW * FIT / aspect);
+    const aspect = w / h;
+    let hH = Math.max(cH, cW / aspect) * MARGIN;
+    for (const l of labels) {
+      const availX = w / 2 - EDGE - l.bx, availY = h / 2 - EDGE - l.by;
+      if (availX > 0) hH = Math.max(hH, l.r * (w / 2) / (availX * aspect));   // px x = l.r/(hH·aspect)·(w/2)
+      if (availY > 0) hH = Math.max(hH, l.u * (h / 2) / availY);              // px y = l.u/hH·(h/2)
+    }
     cam.left = -hH * aspect; cam.right = hH * aspect; cam.top = hH; cam.bottom = -hH; cam.updateProjectionMatrix();
     renderer.setSize(w, h); lr.setSize(w, h);
   }

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -278,7 +278,7 @@ function makeScene(container, build) {
   const scene = new THREE.Scene();
   const cp = (container.dataset.cam || '2.5,-2.6,1.9').split(',').map(Number);
   const tg = (container.dataset.target || '0,0,0.6').split(',').map(Number);
-  // seed half-height only; frame() replaces it with a content fit once the scene is built
+  // orthographic, framed to match the old 42° perspective: half-height = dist(cam,target)·tan(fov/2)
   const halfH = Math.hypot(cp[0]-tg[0], cp[1]-tg[1], cp[2]-tg[2]) * Math.tan(21 * Math.PI/180);
   const cam = new THREE.OrthographicCamera(-halfH*W/H, halfH*W/H, halfH, -halfH, 0.05, 100); cam.up.set(0, 0, 1);
   cam.position.set(cp[0], cp[1], cp[2]);
@@ -297,50 +297,28 @@ function makeScene(container, build) {
   ctr.minZoom = 0.7; ctr.maxZoom = 2.5; // ortho zoom clamps (minDistance/maxDistance are no-ops for OrthographicCamera)
   ctr.target.set(tg[0], tg[1], tg[2]);
   build(scene, THREE, renderer);   // renderer passed so a build can render-to-texture (multi-view capture)
-  // Content-fit framing. The camera is orthographic, so cam.top (hH) IS the zoom — dist(cam,target)
-  // only sets the view direction. Fit hH to the silhouette the camera actually sees: project every
-  // vertex onto the camera's right/up axes. A bounding-sphere estimate cannot do this, because a
-  // sphere's radius is the half-DIAGONAL: stage B's flat view planes and the long storage run
-  // measured ~15% wider than they draw, and the resulting margin was visible as dead space.
+  // responsive framing: keep the tuned vertical extent (halfH) on wide screens, but on narrow (mobile)
+  // viewports zoom out so the full content WIDTH still fits — otherwise wide figures get clipped left/right.
   const target = new THREE.Vector3(tg[0], tg[1], tg[2]);
   const fwd = new THREE.Vector3().subVectors(target, cam.position).normalize();
   const right = new THREE.Vector3().crossVectors(fwd, new THREE.Vector3(0, 0, 1)).normalize();
-  const up = new THREE.Vector3().crossVectors(right, fwd).normalize();
+  // content half-width along the camera's RIGHT axis. Project each mesh's world bounding sphere
+  // (center·right ± radius) instead of an axis-aligned Box3's 8 corners: for a diagonal camera over a
+  // plus-shaped layout (stage B's 4 view planes) the empty AABB corners project onto the 45° right-axis
+  // at ~√2× the true width, which over-zoomed wide figures — worst on mobile, where width binds the fit.
   scene.updateMatrixWorld(true);
-  const tR = target.dot(right), tU = target.dot(up), v = new THREE.Vector3();
-  let cW = 0, cH = 0;   // content half-extents, measured from the target (= the frame centre)
+  const tR = target.dot(right), sph = new THREE.Sphere();
+  let halfW = halfH;
   scene.traverse(o => {
-    if (o.userData.isFloor || !o.geometry) return;   // the floor grid is backdrop, not content
-    const pos = o.geometry.attributes.position; if (!pos) return;
-    for (let i = 0; i < pos.count; i++) {
-      v.fromBufferAttribute(pos, i).applyMatrix4(o.matrixWorld);
-      cW = Math.max(cW, Math.abs(v.dot(right) - tR));
-      cH = Math.max(cH, Math.abs(v.dot(up) - tU));
-    }
+    if (o.userData && o.userData.isFloor || !o.geometry) return;   // skip floor grid and label-only nodes
+    if (!o.geometry.boundingSphere) o.geometry.computeBoundingSphere();
+    sph.copy(o.geometry.boundingSphere).applyMatrix4(o.matrixWorld);
+    halfW = Math.max(halfW, Math.abs(sph.center.dot(right) - tR) + sph.radius);
   });
-  // Labels are fixed-size DOM boxes, so their footprint shrinks as the camera zooms out and cannot be
-  // expressed in world units. Render once to attach them, then solve hH per label so its box clears the
-  // container edge. This replaces the old blanket 1.22 fit factor, which padded every scene for the
-  // worst-case label whether or not that scene had one near an edge.
-  lr.render(scene, cam);
-  const labels = [];
-  scene.traverse(o => {
-    if (!o.isCSS2DObject) return;
-    const wp = o.getWorldPosition(new THREE.Vector3());
-    labels.push({ r: Math.abs(wp.dot(right) - tR), u: Math.abs(wp.dot(up) - tU),
-                  bx: o.element.offsetWidth / 2, by: o.element.offsetHeight / 2 });
-  });
-  const MARGIN = 1.18;   // silhouette fills 1/MARGIN of the card; a tight fit reads cramped, not legible
-  const EDGE = 12;       // px kept clear at the container edge
+  const FIT = 1.22;   // margin so edge labels (CSS2D, wider than their anchor point) aren't clipped
   function frame() {
     const w = container.clientWidth, h = container.clientHeight; if (!w || !h) return;
-    const aspect = w / h;
-    let hH = Math.max(cH, cW / aspect) * MARGIN;
-    for (const l of labels) {
-      const availX = w / 2 - EDGE - l.bx, availY = h / 2 - EDGE - l.by;
-      if (availX > 0) hH = Math.max(hH, l.r * (w / 2) / (availX * aspect));   // px x = l.r/(hH·aspect)·(w/2)
-      if (availY > 0) hH = Math.max(hH, l.u * (h / 2) / availY);              // px y = l.u/hH·(h/2)
-    }
+    const aspect = w / h, hH = Math.max(halfH, halfW * FIT / aspect);
     cam.left = -hH * aspect; cam.right = hH * aspect; cam.top = hH; cam.bottom = -hH; cam.updateProjectionMatrix();
     renderer.setSize(w, h); lr.setSize(w, h);
   }

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -330,8 +330,8 @@ function makeScene(container, build) {
     labels.push({ r: Math.abs(wp.dot(right) - tR), u: Math.abs(wp.dot(up) - tU),
                   bx: o.element.offsetWidth / 2, by: o.element.offsetHeight / 2 });
   });
-  const MARGIN = 1.04;   // breathing room so the silhouette never touches the card edge
-  const EDGE = 6;        // px kept clear at the container edge
+  const MARGIN = 1.18;   // silhouette fills 1/MARGIN of the card; a tight fit reads cramped, not legible
+  const EDGE = 12;       // px kept clear at the container edge
   function frame() {
     const w = container.clientWidth, h = container.clientHeight; if (!w || !h) return;
     const aspect = w / h;

--- a/threesrc/behavior-aware-conflict.js
+++ b/threesrc/behavior-aware-conflict.js
@@ -665,11 +665,17 @@ function buildStageE(scene) {
     scene.add(sphere(gp, 0.06, gr.color));
     nodes.forEach(n => scene.add(sphere(n, 0.03, gr.color)));
     intra.forEach(ij => scene.add(solidEdge(nodes[ij[0]], nodes[ij[1]], gr.color, 0.8)));
+    // Tag every unit's intra edges, not just the work area's: intra-group relations are what makes each
+    // group a functional unit, so labelling one implied the lounge and storage had none.
+    const im = intra.map(ij => mid(nodes[ij[0]], nodes[ij[1]]));
+    const ic = [0, 1, 2].map(k => im.reduce((s, p) => s + p[k], 0) / im.length);
+    // sit just above the intra edges, not up by the group node — each unit's node hovers a different
+    // height above its objects, so a taller lift collides with the short groups' nodes
+    scene.add(label('intra-group', 'g', ic[0], ic[1], ic[2] + 0.12));
     scene.add(label(gr.name, gr.cls, gp[0], gp[1], gp[2] + 0.14));
     gnodes.push(gp);
   });
   [[0, 1], [0, 2], [1, 2]].forEach(ij => scene.add(dashEdge(gnodes[ij[0]], gnodes[ij[1]], 0xd6336c)));
-  scene.add(label('intra-group', 'g', -2.0, -0.15, 1.12));
   const mm = mid(gnodes[0], gnodes[2]);
   scene.add(label('inter-group', 'm', mm[0], mm[1], mm[2] + 0.04));
 }


### PR DESCRIPTION
## Description
**TL;DR:** Polish every figure in the behavior-aware post, and add the paper's Table 1 taxonomy, its references, and an animated figure of the five constraint losses.

- 🎥 Match the **[D]** and **[E]** figure cameras to **[C]**, and centre + fit every figure to its own silhouette.
- 🔗 Link each **[B]** capture box to its view plane corner-to-corner, in the capture-box ink at 0.8 opacity.
- 🏷️ Tag **every** group's intra-group relations in **[E]**, not just the work area.
- 📐 Add **Table 1** (spatial constraint taxonomy) as a MathJax array, and fill **References** with in-text markers `[1]`–`[9]` and links.
- 🎞️ Fill the empty taxonomy figure with a five-panel animation — each constraint's loss pulls its object from violation to satisfied.

## Flow
```mermaid
flowchart LR
  subgraph Taxonomy["Table 1 · 5 constraints, 3 types"]
    direction TB
    P["Position — distance, against wall"]
    O["Orientation — align with, point towards"]
    H["Height — on top of"]
  end
  Taxonomy --> V["Violating placement<br/>high loss"]
  V -->|"move object along −∇ loss"| S["Satisfied placement<br/>loss → 0"]
```

## Losses Figure
Each loss pulls its object from violation → satisfied:

![Taxonomy loss animation — violating vs satisfied endpoints](https://github.com/user-attachments/assets/b78e5a01-5326-4076-9cc7-76bcd7435c74)
