### PR TITLE
Point the related lists at the renamed latent-shapes slug

### DIFF
--- a/note/_posts/2025-03-22-exploring-generative-3d-shapes-using-autoencoder-networks.html
+++ b/note/_posts/2025-03-22-exploring-generative-3d-shapes-using-autoencoder-networks.html
@@ -6,7 +6,7 @@ related:
   - autoencoder
   - deep-sdf
   - representation-learning
-  - latent-shapes
+  - latent-shapes-experiment
   - latent-points
   - auto-encoding-variational-bayes
   - building-gan

--- a/note/_posts/2025-04-05-latent-points.html
+++ b/note/_posts/2025-04-05-latent-points.html
@@ -3,7 +3,7 @@ title:  "Latent Points"
 layout: post
 emoji: /emoji/storm.png
 related:
-  - latent-shapes
+  - latent-shapes-experiment
   - deep-sdf
   - linear-interpolation
   - exploring-generative-3d-shapes-using-autoencoder-networks

--- a/note/_posts/2026-07-19-onnx.html
+++ b/note/_posts/2026-07-19-onnx.html
@@ -5,7 +5,7 @@ mermaid: true
 related:
   - wasm
   - inference-endpoints
-  - latent-shapes
+  - latent-shapes-experiment
 ---
 
 <br>

--- a/testbed/_posts/2023-02-20-three-geometries.html
+++ b/testbed/_posts/2023-02-20-three-geometries.html
@@ -8,7 +8,7 @@ related:
   - three-loaders
   - two-points-perspective
   - selectionbox
-  - latent-shapes
+  - latent-shapes-experiment
   - window-crossing-selection
 ---
 

--- a/testbed/_posts/2023-06-22-drafting-with-ai.html
+++ b/testbed/_posts/2023-06-22-drafting-with-ai.html
@@ -10,7 +10,7 @@ related:
   - landbook-diffusion-pipeline
   - landbook-rendering-with-diffusion
   - synthesized-skyscrapers
-  - latent-shapes
+  - latent-shapes-experiment
   - intuitions-about-diffusion-models
 ---
 

--- a/testbed/_posts/2023-10-23-mass-gans.html
+++ b/testbed/_posts/2023-10-23-mass-gans.html
@@ -9,7 +9,7 @@ thumbnail: /img/latent-masses-thumbnail.gif
 related:
   - geometric-deep-learning
   - voxels-to-graph
-  - latent-shapes
+  - latent-shapes-experiment
   - synthesized-skyscrapers
   - building-gan
   - gan

--- a/testbed/_posts/2024-03-01-synthesized-skyscrapers.html
+++ b/testbed/_posts/2024-03-01-synthesized-skyscrapers.html
@@ -7,7 +7,7 @@ splitter: 1
 thumbnail: /img/synthesized-skyscrapers-9.gif
 related:
   - mass-gans
-  - latent-shapes
+  - latent-shapes-experiment
   - voxels-to-graph
   - landbook-diffusion-pipeline
   - drafting-with-ai

--- a/testbed/_posts/2026-02-03-image-to-3d-scene.html
+++ b/testbed/_posts/2026-02-03-image-to-3d-scene.html
@@ -9,7 +9,7 @@ inprogress: false
 at: Visual Media Lab
 thumbnail: /img/image-to-3d-scene/image-to-3d-scene-thumbnail.png
 related:
-  - latent-shapes
+  - latent-shapes-experiment
   - synthesized-skyscrapers
   - mass-gans
   - local-coordinate-system


### PR DESCRIPTION
## Description
**TL;DR:** A rename left 8 posts pointing at a slug that no longer exists, so their edges quietly disappeared from the post map.

- 🔗 `- latent-shapes` → `- latent-shapes-experiment` in **8 posts**
- 📈 Incoming edges to that post: **1 → 9**
- ✅ One line per file, `+8 −8`, nothing else touched

## Flow

```mermaid
flowchart LR
  OLD["8 posts say<br/>- latent-shapes"] --> CHK{"is there a post<br/>with that slug?"}
  NEW["8 posts say<br/>- latent-shapes-experiment"] --> CHK
  CHK -->|"no — renamed in 7da070f"| DROP["edge dropped<br/>silently, no error"]
  CHK -->|yes| DRAW["edge drawn<br/>on the post map"]
```

`7da070f` renamed `2025-08-11-latent-shapes.html` → `2025-08-11-latent-shapes-experiment.html`. The slug moved with the file; the eight posts listing it did not.

## Before / After

| <img alt="" width="600" height="1"><br>Before | <img alt="" width="600" height="1"><br>After |
|---|---|
| **1** incoming edge | **9** incoming edges |
| only `coarse-to-fine-sdf` | `coarse-to-fine-sdf` + the 8 below |
| 6 of its 9 outgoing edges got no reply | every declared link resolves |
| nothing errored — the map just drew less | `0` related entries match no post |

## Repointed

| Post |
|---|
| `note/_posts/2025-03-22-exploring-generative-3d-shapes-using-autoencoder-networks.html` |
| `note/_posts/2025-04-05-latent-points.html` |
| `note/_posts/2026-07-19-onnx.html` |
| `testbed/_posts/2023-02-20-three-geometries.html` |
| `testbed/_posts/2023-06-22-drafting-with-ai.html` |
| `testbed/_posts/2023-10-23-mass-gans.html` |
| `testbed/_posts/2024-03-01-synthesized-skyscrapers.html` |
| `testbed/_posts/2026-02-03-image-to-3d-scene.html` |

## Checks

| <img alt="" width="600" height="1"><br>Check | <img alt="" width="600" height="1"><br>Result |
|---|---|
| `verify_related.py` | 190 / 190 valid |
| `bundle exec jekyll build` | passes |
| next map build, simulated | `0` entries match no post · incoming `1 → 9` |
| slug listed twice anywhere | none |
| post referencing itself | none |
| `^  - latent-shapes$` anchored both ends | `coarse-to-fine-sdf`, already on the new slug, untouched |

`build-latentspace` runs on push to `main` touching `_posts/**`, so the edges come back on merge.

https://claude.ai/code/session_015wdMJNMWvaNEjWFpfKEqcE
