### PR TITLE
Use body text color in chat-style posts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,7 +44,6 @@ same shape; do not introduce a non-fluid `px`-only size.
 | `$featured-color` | `#0011e3` | Featured underline (`u.wavy-underline`), pinned title bg |
 | `$inprogress-color` | `#1aff00` | WIP underline |
 | `$bg-subtle` | `#f7f7f8` | Chat bubble + code block background |
-| `$text-chat` | `#343541` | Chat-style body text |
 | `$divider` | `#e5e5e6` | Horizontal rule, hairline divider |
 | `$link-chat` | `#4b83ec` | Link inside chat bubbles |
 

--- a/_sass/basic.sass
+++ b/_sass/basic.sass
@@ -225,7 +225,6 @@ div.article
 
 .chat-message.assistant .message-content
   background-color: $light
-  color: $text-chat
 
 .message-content table
   width: 100%
@@ -240,7 +239,6 @@ hr
   margin-top: 20px
   margin-bottom: 10px
   font-size: 1.1em
-  color: $text-chat
 
 .message-content a
   color: $link-chat

--- a/_sass/index.sass
+++ b/_sass/index.sass
@@ -12,7 +12,6 @@ $light: #ffffff !default
 
 // Surface tokens for chat-style content (note posts use chat bubbles)
 $bg-subtle: #f7f7f8 !default
-$text-chat: #343541 !default
 $divider: #e5e5e6 !default
 $link-chat: #4b83ec !default
 


### PR DESCRIPTION
## Description
**TL;DR:** Chat posts stop overriding the page text color, so their text is black like every other post.
- 🎨 `_sass/basic.sass` — dropped `color: $text-chat` from `.chat-message.assistant .message-content` and `.message-content h3`
- 🗑️ `_sass/index.sass` + `DESIGN.md` — removed the now-unused `$text-chat` token and its table row
- ✅ Deletions only: 4 lines, 3 files, no new CSS

## Flow
```mermaid
flowchart LR
  A[Assistant bubble text] --> B{color declared on<br/>.message-content?}
  B -->|before: $text-chat| C["343541 blue-gray<br/>12.1:1 contrast"]
  B -->|after: declaration gone| D["inherits body $dark<br/>000000 black · 21:1"]
  E[User bubble] --> F["$light on $dark<br/>unchanged"]
```

## Before / After
| <img alt="" width="600" height="1"><br>Before · `#343541` · 12.1:1 | <img alt="" width="600" height="1"><br>After · `#000000` · 21:1 |
|---|---|
| <img src="https://github.com/user-attachments/assets/6fadbe7e-7c88-410e-9a53-a7d7ae8babfe" alt="before" width="600"> | <img src="https://github.com/user-attachments/assets/10143149-81c0-4b8e-becb-16a498773d38" alt="after" width="600"> |

Same crop of `/some-truth/`, same scroll, only the sass differs.

## Untouched
| <img alt="" width="600" height="1"><br>Thing | <img alt="" width="600" height="1"><br>Still |
|---|---|
| User bubble text | `rgb(255, 255, 255)` on `$dark` |
| Link in bubble | `$link-chat` → `rgb(75, 131, 236)` |
| `h3` in bubble | `1.1em` + margins; only its color line went |
| Bubble bg, radius, padding | unchanged |

## Affects
All 6 chat posts: `thinking-of-lying`, `inductive-bias-2`, `extrapolation`, `truth`, `some-truth`, `verbalization-loss` (#106).

## Verified
- `bundle exec jekyll build` → exit 0
- `/some-truth/` assistant `<p>` computed color: `rgb(52, 53, 65)` → `rgb(0, 0, 0)`, matching `body`
- `/extrapolation/` `h3` in bubble: `rgb(0, 0, 0)`, font-size still `15.12px` (`1.1em`)
