### PR TITLE
Inherit page font for MathJax text runs

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,6 +14,13 @@ layout: default
     tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]},
     TeX: {
       extensions: ["cancel.js"]
+    },
+    // MathJax's TeX fonts carry no Hangul, so \text{한국어} was drawn with a
+    // substituted system font inside boxes whose widths came from the missing
+    // TeX metrics — glyphs collided ("머릿속" rendered as "ㅁㅓ릿속"). Inheriting
+    // the page font makes the browser lay the run out with matching metrics.
+    CommonHTML: {
+      mtextFontInherit: true
     }
   });
 </script>


### PR DESCRIPTION
Korean inside `\text{}` rendered with colliding characters. `\text{머릿속}` came out looking like `ㅁㅓ릿속`.

## Cause

MathJax's TeX fonts carry no Hangul. The browser substitutes a system Korean font per character, but MathJax has already reserved each character's width from its own (missing) TeX metrics. The glyph drawn and the box reserved for it disagree, so characters collide.

## Change

One config flag in `_layouts/post.html`:

```js
CommonHTML: { mtextFontInherit: true }
```

`\text{}` runs now inherit the page font, so the browser lays them out with metrics that match the glyphs it actually draws.

## Result

| Before | After |
|---|---|
| `ㅁㅓ릿속 사고의표현형식 ≠ 언ㅇㅓ의표현형식` | `머릿속 사고의 표현 형식 ≠ 언어의 표현 형식` |
| arrows cramped against text | `내부 사고 → 언어화 → AI의 해석 → 구조화된 언어` |

## Trade-off — read this before merging

This is site-wide, not one post. **43 posts use `\text{}`**, and in all of them those runs switch from TeX roman to the page font (PT Sans).

Checked on `/chamfer-distance/`: `\text{Chamfer Distance}(P, Q) = …` now renders sans-serif, while every real math symbol (`P`, `Q`, `min`, `Σ`, `‖·‖`, fractions, subscripts) keeps the TeX font unchanged. Legible and consistent with body text, but it *is* a visible restyle across the math posts.

## Ruled out

`_sass/basic.sass:172` has `.mjx-char { font-size: 90% !important }`, which looked like a suspect. Setting it to 100% made the text slightly larger but did **not** fix the collisions. Left untouched.

## Verification

- `bundle exec jekyll build` exits 0
- `/verbalization-loss/` (Korean, from #106): 52 display blocks, 0 `.mjx-merror`, all 19 `\boxed` borders intact at `1px solid rgb(0, 0, 0)`
- `/chamfer-distance/` (English): 3 display blocks, 0 errors, symbols unchanged
