### PR TITLE
Stop shrinking MathJax glyphs to 90%

### DIFF
--- a/_sass/basic.sass
+++ b/_sass/basic.sass
@@ -169,9 +169,6 @@ div.article
 .mjx-sub 
   font-size: 90% !important
 
-.mjx-char 
-  font-size: 90% !important
-  
 .MJXc-display
   font-size: 100% !important
   


### PR DESCRIPTION
## Description
**TL;DR:** One CSS rule was shrinking MathJax's glyphs under its own layout, so text inside math ran together. Deleting it fixes the crowding.
- 🗑️ `_sass/basic.sass` — removed `.mjx-char { font-size: 90% !important }`
- 📏 Deletions only: 3 lines, 1 file
- ⚠️ Site-wide: math renders ~11% larger, at the size MathJax intended

## Flow
```mermaid
flowchart LR
  A[MathJax lays out math] --> B[reserves widths at its own size]
  B --> C{".mjx-char forces 90%?"}
  C -->|"before: yes"| D["glyphs drawn smaller<br/>under unchanged layout<br/>→ words crowd"]
  C -->|"after: rule gone"| E["glyphs match layout<br/>→ correct spacing"]
```

## Before / After
| <img alt="" width="600" height="1"><br>Before · crowded | <img alt="" width="600" height="1"><br>After · correct |
|---|---|
| <img src="https://github.com/user-attachments/assets/8ae195c3-fdf1-477b-8aa5-692b6fd0bc31" alt="before" width="600"> | <img src="https://github.com/user-attachments/assets/ceb12305-a352-418e-a01c-459f6811c573" alt="after" width="600"> |

Same crop of `/verbalization-loss/`, same window, only the one rule differs.

## Why only one rule
| <img alt="" width="600" height="1"><br>Build | <img alt="" width="600" height="1"><br>`.mjx-char` size | <img alt="" width="600" height="1"><br>Result |
|---|---|---|
| current `main` | `12.37px` | crowded |
| **this PR** — `.mjx-char` removed | `13.74px` | correct |
| all five `.mjx-*` rules removed | `15.53px` | correct |

Removing the one rule already matches the all-five render, so the other four stay.

## Verified
| <img alt="" width="600" height="1"><br>Check | <img alt="" width="600" height="1"><br>Result |
|---|---|
| `bundle exec jekyll build` | exit 0 |
| `/verbalization-loss/` (Korean, #106) | 52 display blocks, 0 `.mjx-merror` |
| `/chamfer-distance/` (English) | 3 blocks, 0 errors; `\text{Chamfer Distance}(P,Q)` keeps TeX roman, spacing correct |

## Supersedes #108 (closed)
#108 proposed `mtextFontInherit`. Measuring 115 text/symbol pairs with that flag on and off returned identical numbers — same `text` → `)` gap of `0`, same worst-offender list. It fixed nothing, and its stated cause was wrong.
